### PR TITLE
Add a `BugReports` entry to `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Description: caugi is a package for creating, querying, and processing
     causal graphs.
 License: MIT + file LICENSE
 URL: https://frederikfabriciusbjerre.github.io/caugi/
+BugReports: https://github.com/frederikfabriciusbjerre/caugi/issues
 Depends: 
     R (>= 4.2)
 Imports:


### PR DESCRIPTION
You can add this field to direct users to where they should submit bugs.

By the way, the URL field can contain multiple urls, so you could list your github repo url there too.