### PR TITLE
Fix some typos, grammatical, and punctuation errors

### DIFF
--- a/vignettes/get_started.Rmd
+++ b/vignettes/get_started.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 library(caugi)
 ```
 
-In this vignette, we will walk you through on how to create a `caugi`, query it, modify it, and then compare it to other `caugi`s. 
+In this vignette, we will walk you through how to create a `caugi`, query it, modify it, and then compare it to other `caugi`s. 
 
 ## The `caugi` object
 
@@ -35,7 +35,7 @@ cg <- caugi(
 cg
 ```
 
-You might scratch your head a bit, when looking at the call above. To clarify, `A %-->% B` creates the edge `-->` from `A` to `B`. The syntax `B %-->% C + D` is equivalent to `B %--> C` _and_ `B %-->% D`. Notice that the graph prints two `tibbles`. The first is equivalent to `cg@nodes` and the second `cg@edges`. Besides that the `caugi` holds other _properties_. Let's check the other properties. 
+You might scratch your head a bit, when looking at the call above. To clarify, `A %-->% B` creates the edge `-->` from `A` to `B`. The syntax `B %-->% C + D` is equivalent to `B %--> C` _and_ `B %-->% D`. Notice that the graph prints two `tibbles`. The first is equivalent to `cg@nodes` and the second `cg@edges`. Besides that, the `caugi` holds other _properties_. Let's check the other properties.
 
 ### Properties
 
@@ -130,7 +130,7 @@ This indicates whether the graph has been "built" or not on the Rust side. This 
 cg@name_index_map
 ```
 
-The `name_index_map` is a hashmap that takes node names as keys and output zero-based indices. This is use to access nodes' zero-based indices,, when converting node names to indices for Rust calls, as the Rust backend uses zero-based indices. 
+The `name_index_map` is a hashmap that takes node names as keys and outputs zero-based indices. This is used to access nodes' zero-based indices, when converting node names to indices for Rust calls, as the Rust backend uses zero-based indices. 
 
 #### `.state`
 
@@ -138,5 +138,5 @@ The `name_index_map` is a hashmap that takes node names as keys and output zero-
 cg@.state
 ```
 
-This is the internal state of the `caugi` graph object. It is used to ensure that the `caugi` object can be modifying in R and, so to say, _saves_ the modifications you might make to the graph in R without having to rebuild the graph in Rust each time. The most important takeaways about the state is that you should _avoid_ modifying the state directly. Instead, you should use the verbs.  
+This is the internal state of the `caugi` graph object. It is used to ensure that the `caugi` object can be modified in R and, so to speak, _saves_ the modifications you might make to the graph in R without having to rebuild the graph in Rust each time. The most important takeaway about the state is that you should _avoid_ modifying the state directly. Instead, you should use the verbs.
 

--- a/vignettes/motivation.Rmd
+++ b/vignettes/motivation.Rmd
@@ -54,15 +54,15 @@ caugi(
 
 The second form reads like the picture in your head.
 
-For people working in causal inference and causal discovery, the lack of readable, well supported formats can lead to clunky, hacky code that is hard to read and maintain. `caugi` aims to fix this with a readable syntax, which mimics how we draw graphs in hand, and gives the user the ability to express complex causal relationships.
+For people working in causal inference and causal discovery, the lack of readable, well supported formats can lead to clunky, hacky code that is hard to read and maintain. `caugi` aims to fix this with a readable syntax, which mimics how we draw graphs by hand, and gives the user the ability to express complex causal relationships.
 
 ## Safety
 
 When makeshift solutions are used to represent causal graphs, it leads to not only bugs, but confusion and wasted time. With `caugi` we aim to make causal graphs safe to work with, so you do not accidentally create invalid graphs, and so you can focus on the causal problems at hand, not on the representation.
 
-We have ensured that `caugi` graph object it should not be possible to alter in such a way that the underlying graph class becomes valid. For example, creating a DAG with `caugi`, acyclicity is guaranteed by construction. Trying to add an edge that would create a cycle will throw an error. 
+We have ensured that the `caugi` graph object should be impossible to alter in such a way that the underlying graph class becomes invalid. For example, creating a DAG with `caugi`, acyclicity is guaranteed by construction. Trying to add an edge that would create a cycle will throw an error. 
 
-More generally, all `caugi` aims to be __graph-class safe__. Think of it as type safety, but on a graph class level. This safety comes at some costs; if `caugi` doesn't support the graph type, you are using, then the graph class should be set to `"UNKNOWN"`, and most operations will not be available, since the interpretation of the relationships described by the graph is _unknown_ to `caugi`. However, this is a small price to pay for safety and clarity. In `caugi`, we prefer clarity over silent misinterpretation. `caugi` will act as your causality guard dog 🐶
+More generally, `caugi` aims to be __graph-class safe__. Think of it as type safety, but on a graph-class level. This safety comes at some costs; if `caugi` doesn't support the graph type you are using, then the graph class should be set to `"UNKNOWN"`, and most operations will not be available, since the interpretation of the relationships described by the graph is _unknown_ to `caugi`. However, this is a small price to pay for safety and clarity. In `caugi`, we prefer clarity over silent misinterpretation. `caugi` will act as your causality guard dog 🐶
 
 We refer to the vignette `vignette("package_use")` to see how to (safely) use `caugi` in your package.
 

--- a/vignettes/package_use.Rmd
+++ b/vignettes/package_use.Rmd
@@ -22,7 +22,7 @@ set.seed(42)
 Now, let's see how you can use `caugi` in your own R package. We will work through an example to illustrate how you could approach this.
 
 ## The setup
-Imagine that you want to build a causal discovery function that utilizes `caugi` for graph representation and manipulation. While seemingly not a very good idea, let's pretend your algorithmic idea is to measure the correlation between variables and then drawing causal conclusions based on this^[Note that correlation does not imply causation!]. 
+Imagine that you want to build a causal discovery function that utilizes `caugi` for graph representation and manipulation. While seemingly not a very good idea, let's pretend your algorithmic idea is to measure the correlation between variables and then draw causal conclusions based on this^[Note that correlation does not imply causation!]. 
 
 ```{r first-iteration}
 #' @title Correlation implies causation!
@@ -62,7 +62,7 @@ Now, we _know_ that the `caugi` should include all variables in the `df`. We don
 #'
 #' @returns A `caugi` representing the causal graph that is totally true!
 correlation_implies_causation <- function(df) {
-  cg <- caugi(nodes = names(df))
+  cg <- caugi::caugi(nodes = names(df))
   return(NULL)
 }
 ```
@@ -78,7 +78,7 @@ We can now compute the correlation matrix and add edges based on some arbitrary 
 #'
 #' @returns A `caugi` representing the causal graph that is totally true!
 correlation_implies_causation <- function(df) {
-  cg <- caugi(nodes = names(df))
+  cg <- caugi::caugi(nodes = names(df))
   cor_matrix <- cor(df)
   # Add edges for correlations above 0.5
   for (i in seq_len(ncol(cor_matrix))) {
@@ -86,7 +86,7 @@ correlation_implies_causation <- function(df) {
       if (i != j && abs(cor_matrix[i, j]) > 0.5) {
         from <- names(df)[j]
         to <- names(df)[i]
-        cg <- add_edges(cg, from = from, edge = "-->", to = to) # add edge to caugi
+        cg <- caugi::add_edges(cg, from = from, edge = "-->", to = to) # add edge to caugi
       }
     }
   }
@@ -122,7 +122,7 @@ We can see that the object is not built yet. So, we have to include that as well
 #'
 #' @returns A `caugi` representing the causal graph that is totally true!
 correlation_implies_causation <- function(df) {
-  cg <- caugi(nodes = names(df))
+  cg <- caugi::caugi(nodes = names(df))
   cor_matrix <- cor(df)
   # Add edges for correlations above 0.5
   for (i in seq_len(ncol(cor_matrix))) {
@@ -130,11 +130,11 @@ correlation_implies_causation <- function(df) {
       if (i != j && abs(cor_matrix[i, j]) > 0.5) {
         from <- names(df)[j]
         to <- names(df)[i]
-        cg <- add_edges(cg, from = from, edge = "-->", to = to) # add edge to caugi
+        cg <- caugi::add_edges(cg, from = from, edge = "-->", to = to) # add edge to caugi
       }
     }
   }
-  build(cg)
+  caugi::build(cg)
   return(cg)
 }
 ```
@@ -144,7 +144,7 @@ You _can_ ensure that your algorithm breaks, when introducing a faulty edge by b
 
 ## Class of the output
 
-Now, you might want to specify the class of the output graph. Let's say that _if possible_ the output should be a DAG (which is advantageous for several reasons), but you don't want to enforce acyclicity in the algorithm, as that could sometimes make your function error. You would rather have it return a graph in any case, but if it _is_ a DAG, then we return a DAG. 
+Now, you might want to specify the class of the output graph. Let's say that _if possible_ the output should be a DAG (which is advantageous for several reasons), but you don't want to enforce acyclicity in the algorithm, as that could sometimes cause your function to throw an error. You would rather have it return a graph in any case, but if it _is_ a DAG, then we return a DAG. 
 
 This is not ideal in `caugi`. Because of the way `caugi` works, this is a bit slower, but we can still do it! 
 
@@ -155,10 +155,10 @@ This is not ideal in `caugi`. Because of the way `caugi` works, this is a bit sl
 #'
 #' @returns A `caugi` representing the causal graph that is totally true!
 correlation_implies_causation <- function(df) {
-  cg <- caugi(nodes = names(df))
+  cg <- caugi::caugi(nodes = names(df))
   cor_matrix <- cor(df)
   # Add edges for correlations above 0.5
-  cg <- caugi(nodes = names(df))
+  cg <- caugi::caugi(nodes = names(df))
   cor_matrix <- cor(df)
   # Add edges for correlations above 0.5
   for (i in seq_len(ncol(cor_matrix))) {
@@ -166,17 +166,17 @@ correlation_implies_causation <- function(df) {
       if (i != j && abs(cor_matrix[i, j]) > 0.5) {
         from <- names(df)[j]
         to <- names(df)[i]
-        cg <- add_edges(cg, from = from, edge = "-->", to = to) # add edge to caugi
+        cg <- caugi::add_edges(cg, from = from, edge = "-->", to = to) # add edge to caugi
       }
     }
   }
   it_is <- is_dag(cg) # this builds, since it is a query
   if (it_is) {
-    cg <- caugi(
-      from = edges(cg)$from,
-      edge = edges(cg)$edge,
-      to = edges(cg)$to,
-      nodes = nodes(cg)$name,
+    cg <- caugi::caugi(
+      from = caugi::edges(cg)$from,
+      edge = caugi::edges(cg)$edge,
+      to = caugi::edges(cg)$to,
+      nodes = caugi::nodes(cg)$name,
       class = "DAG"
     )
   }

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -24,15 +24,15 @@ That is, `caugi` spends more effort when constructing a graph and preparing inde
 
 #### Compressed Sparse Row (CSR) representation
 
-The core data structure in `caugi` is a Compressed Sparse Row (CSR) representation of the graph.
-CSR stores for each vertex a contiguous slice of neighbor IDs with a pointer (offset) array that marks the start/end of each slice.
+The core data structure in `caugi` is a compressed sparse row (CSR) representation of the graph.
+CSR representations store for each vertex a contiguous slice of neighbor IDs with a pointer (offset) array that marks the start/end of each slice.
 This format is memory efficient for sparse graphs. The `caugi` graph object also stores important query information in the object, leading to parent, child, and neighbor queries being done in $\mathcal{O}(1)$. This yields a larger memory footprint, but the trade-off is that queries are extremely fast.
 
 #### Mutation and lazy building
 
-The `caugi` graph objects are expensive to build. This is the performance downside of using `caugi`. For each time, we make a modification to a `caugi` graph object, we need to rebuild the graph completely, since the graph object is immutable by design. This has complexity $\mathcal{O}(|V| + |E|)$, where $V$ is the vertex set and $E$ is the edge set. 
+The `caugi` graph objects are expensive to build. This is the performance downside of using `caugi`. For each time we make a modification to a `caugi` graph object, we need to rebuild the graph completely since the graph object is immutable by design. This has complexity $\mathcal{O}(|V| + |E|)$, where $V$ is the vertex set and $E$ is the edge set. 
 
-However, the graph object will only be rebuild, when the user either calls `build()` directly or queries the graph. Therefore, you do not need to worry about wasting compute time by iteratively making changes to a `caugi` graph object, as the graph rebuilds lazily when queried. By doing this `caugi` graphs _feel_ mutable, but, in reality, they are not. 
+However, the graph object will only be rebuilt when the user either calls `build()` directly or queries the graph. Therefore, you do not need to worry about wasting compute time by iteratively making changes to a `caugi` graph object, as the graph rebuilds lazily when queried. By doing this, `caugi` graphs _feel_ mutable, but, in reality, they are not. 
 
 By doing it this way, we ensure 
 - that the graph object is always in a consistent state when queried, and
@@ -161,7 +161,7 @@ bench::mark(
 
 #### Subgraph (building)
 
-Here we see an example of where the frontloading hurts performance. When we build a subgraph, we have to rebuild the entire `caugi` graph object. Here, we see that while `caugi` outperforms other packages for queries (except for parents/children for `bnlearn`), it is slower for building the graph objects themselves, which shows for the subgraph benchmark:
+Here we see an example of where the frontloading hurts performance. When we build a subgraph, we have to rebuild the entire `caugi` graph object. Here, we see that while `caugi` outperforms other packages for queries (except for parents/children for `bnlearn`), it is slower for building the graph objects themselves, which shows in the subgraph benchmark:
 
 ```{r benchmark-subgraph}
 subgraph_nodes_index <- sample.int(1000, 500)


### PR DESCRIPTION
Here are some edits to grammatical and punctuation errors as well as typos. 

I also think it makes sense to use `caugi::` in the package vignette, since that's good practice and also clarifies what's coming from caugi.