### PR TITLE
Add dependabot to repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "cargo"
-    directory: "/"
+    directory: "/src/rust/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This will help automatize updating of github actions and crates.

I wasn't entirely sure about the paths for the crates part here because it resides in a R package, but we could try and see if it works and change otherwise.