### PR TITLE
docs: add opengraph image to pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,10 @@
 url: https://caugi.org/
 template:
   bootstrap: 5
+  opengraph:
+    image:
+      src: man/figures/og.png
+      alt: "The name 'caugi' on the left and a graph on the right with corgi dogs as nodes."
 
 reference:
   - title: The caugi object


### PR DESCRIPTION
Adds the opengraph image to the pkgdown site.