### PR TITLE
docs: add logo to readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# caugi
+# caugi <a href="https://caugi.org"><img src='man/figures/logo.svg' align="right" height="138" /></a>
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/frederikfabriciusbjerre/caugi/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/frederikfabriciusbjerre/caugi/actions/workflows/R-CMD-check.yaml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# caugi
+# caugi <a href="https://caugi.org"><img src='man/figures/logo.svg' align="right" height="138" /></a>
 
 <!-- badges: start -->
 


### PR DESCRIPTION
I think we should add the logo back to the readme. I think the duplicated logo was maybe because you also used the logo option from pkgdown or something, which I guess we're not using anymore.