### PR TITLE
docs: add pkgdown development mode auto

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,9 @@
 url: https://caugi.org/
 title: "caugi"
 
+development:
+  mode: auto
+
 home:
   title: "Causal Graph Interface"
   description: Create, query, and modify causal graphs. 'caugi' (Causal Graph Interface) is a causality-first, high performance graph package that provides a simple interface to build, structure, and examine causal relationships.


### PR DESCRIPTION
This will add a version of the docs for current development, which is quite nice since users can then refer to the stable docs or development docs depending on how they are installing caugi.

Like this: https://jolars.github.io/SLOPE/dev/, https://jolars.github.io/SLOPE/dev/

Maybe this only works if you are using .9000 as a development version, which I just realized that I seem to be doing as well, at least for this package...!