### PR TITLE
Add title parameter to `plot()` and improve margin handling

### DIFF
--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -18,6 +18,10 @@ any additional arguments passed via \code{...}.
 \item A pre-computed layout data.frame with columns \code{name}, \code{x}, and \code{y}.
 }}
 
+\item{...}{Additional arguments passed to \code{\link[=caugi_layout]{caugi_layout()}}. For bipartite
+layouts, include \code{partition} (logical vector) and \code{orientation} (\code{"rows"}
+or \code{"columns"}).}
+
 \item{node_style}{List of node styling parameters. Supports:
 \itemize{
 \item Appearance (passed to \code{gpar()}): \code{fill}, \code{col}, \code{lwd}, \code{lty}, \code{alpha}
@@ -39,7 +43,20 @@ Supports:
 \code{fontfamily}, \code{cex}
 }}
 
-\item{...}{Additional arguments (currently unused).}
+\item{main}{Optional character string for plot title. If \code{NULL} (default),
+no title is displayed.}
+
+\item{title_style}{List of title styling parameters. Supports:
+\itemize{
+\item Appearance (passed to \code{gpar()}): \code{col}, \code{fontsize}, \code{fontface},
+\code{fontfamily}, \code{cex}
+}}
+
+\item{outer_margin}{Grid unit specifying outer margin around the plot.
+Default is \code{grid::unit(2, "mm")}.}
+
+\item{title_gap}{Grid unit specifying gap between title and graph.
+Default is \code{grid::unit(1, "lines")}.}
 }
 \value{
 A \code{caugi_plot} object that wraps a \code{gTree} for grid graphics
@@ -87,6 +104,16 @@ plot(
     directed = list(col = "blue", arrow_size = 4),
     undirected = list(col = "red")
   )
+)
+
+# Add a title
+plot(cg, main = "Causal Graph")
+
+# Customize title
+plot(
+  cg,
+  main = "My Graph",
+  title_style = list(fontsize = 18, col = "blue", fontface = "italic")
 )
 
 }

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -98,6 +98,62 @@ test_that("plot.caugi builds graph if needed", {
   expect_s7_class(plot(cg), caugi_plot)
 })
 
+test_that("plot.caugi applies margins and title padding", {
+  cg <- caugi(A %-->% B)
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  p <- plot(cg, main = "Title")
+  graph <- grid::getGrob(p@grob, "caugi.graph")
+  layout <- graph$vp[[1]]$layout
+
+  margin_widths <- grid::convertWidth(
+    layout$widths[c(1, 3)],
+    "mm",
+    valueOnly = TRUE
+  )
+  expect_true(all(margin_widths > 0))
+  expect_equal(margin_widths[1], margin_widths[2])
+
+  top_bottom_margins <- grid::convertHeight(
+    layout$heights[c(1, 5)],
+    "mm",
+    valueOnly = TRUE
+  )
+  expect_true(all(top_bottom_margins > 0))
+  expect_equal(top_bottom_margins[1], top_bottom_margins[2])
+
+  expect_gt(
+    grid::convertHeight(layout$heights[[2]], "mm", valueOnly = TRUE),
+    0
+  )
+  expect_gt(
+    grid::convertHeight(layout$heights[[3]], "mm", valueOnly = TRUE),
+    0
+  )
+})
+
+test_that("plot.caugi omits title spacing when main is NULL", {
+  cg <- caugi(A %-->% B)
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  p <- plot(cg)
+  graph <- grid::getGrob(p@grob, "caugi.graph")
+  layout <- graph$vp[[1]]$layout
+
+  expect_equal(
+    grid::convertHeight(layout$heights[[2]], "mm", valueOnly = TRUE),
+    0
+  )
+  expect_equal(
+    grid::convertHeight(layout$heights[[3]], "mm", valueOnly = TRUE),
+    0
+  )
+})
+
 test_that("caugi_layout works with fruchterman-reingold method", {
   cg <- caugi(
     A %-->% B + C,

--- a/vignettes/visualization.Rmd
+++ b/vignettes/visualization.Rmd
@@ -69,7 +69,7 @@ dag <- caugi(
 )
 
 # Use Sugiyama layout explicitly
-plot(dag, layout = "sugiyama")
+plot(dag, layout = "sugiyama", main = "Sugiyama")
 ```
 
 **Best for:** DAGs, causal models, hierarchical structures
@@ -92,7 +92,7 @@ admg <- caugi(
 )
 
 # Fruchterman-Reingold handles all edge types
-plot(admg, layout = "fruchterman-reingold")
+plot(admg, layout = "fruchterman-reingold", main = "Fruchterman-Reingold")
 ```
 
 **Best for:** General-purpose visualization, graphs with mixed edge types
@@ -116,7 +116,7 @@ ug <- caugi(
 )
 
 # Kamada-Kawai for publication-quality visualization
-plot(ug, layout = "kamada-kawai")
+plot(ug, layout = "kamada-kawai", main = "Kamada-Kawai")
 ```
 
 **Best for:** Publication-quality figures, when accurate distance
@@ -261,6 +261,7 @@ Customize node labels with the `label_style` parameter:
 # Customize label appearance
 plot(
   cg,
+  main = "Customized Labels",
   label_style = list(
     col = "white", # Text color
     fontsize = 12, # Font size


### PR DESCRIPTION
Also add a `main_style` parameter to handle styling.

And add `outer_margin` and `title_gap` to handle margins around plot and between title and plot area, which much more reasonable handling of the former.

``` r
library(caugi)

cg <- caugi(
  Albert %-->% Beatrix,
  Beatrix %-->% Charles,
  Albert %-->% Charles
)

plot(
  cg,
  main = "Simple Causal Graph",
  title_style = list(fontsize = 16, fontface = "italic", col = "blue")
)
```

![](https://i.imgur.com/GfticGk.png)<!-- -->

<sup>Created on 2025-12-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>