### PR TITLE
Visualize partial edges correctly

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -30,6 +30,7 @@ caugi_default_options <- function() {
       ),
       edge_style = list(
         arrow_size = 3,
+        circle_size = 1.5,
         fill = "black"
       ),
       label_style = list(),
@@ -65,6 +66,7 @@ caugi_default_options <- function() {
 #'   - `size`: Size multiplier (default: `1`)
 #' - `edge_style`: List of default edge appearance parameters:
 #'   - `arrow_size`: Arrow size in mm (default: `3`)
+#'   - `circle_size`: Radius of endpoint circles for partial edges in mm (default: `1.5`)
 #'   - `fill`: Arrow/line color (default: `"black"`)
 #' - `label_style`: List of label text parameters (see [grid::gpar()])
 #' - `title_style`: List of title text parameters:

--- a/man/caugi_options.Rd
+++ b/man/caugi_options.Rd
@@ -33,6 +33,7 @@ Currently supported options are nested under the \code{plot} key:
 \item \code{edge_style}: List of default edge appearance parameters:
 \itemize{
 \item \code{arrow_size}: Arrow size in mm (default: \code{3})
+\item \code{circle_size}: Radius of endpoint circles for partial edges in mm (default: \code{1.5})
 \item \code{fill}: Arrow/line color (default: \code{"black"})
 }
 \item \code{label_style}: List of label text parameters (see \code{\link[grid:gpar]{grid::gpar()}})

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -34,7 +34,8 @@ or per-type options via \code{directed}, \code{undirected}, \code{bidirected}, \
 Supports:
 \itemize{
 \item Appearance (passed to \code{gpar()}): \code{col}, \code{lwd}, \code{lty}, \code{alpha}, \code{fill}.
-\item Geometry: \code{arrow_size} (arrow length in mm, default 3)
+\item Geometry: \code{arrow_size} (arrow length in mm, default 3), \code{circle_size}
+(radius of endpoint circles for partial edges in mm, default 1.5)
 }}
 
 \item{label_style}{List of label styling parameters. Supports:

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -400,3 +400,54 @@ test_that("plot arguments override global options", {
   p <- plot(cg, node_style = list(fill = "pink"))
   expect_s7_class(p, caugi_plot)
 })
+
+test_that("plot.caugi renders o-> edges with circles", {
+  cg <- caugi(A %o->% B, class = "UNKNOWN")
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # Test that plot completes without error and renders circles
+  expect_s7_class(plot(cg), caugi_plot)
+})
+
+test_that("plot.caugi renders o-o edges with circles on both ends", {
+  cg <- caugi(A %o-o% B, class = "UNKNOWN")
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # Test that plot completes without error and renders circles
+  expect_s7_class(plot(cg), caugi_plot)
+})
+
+test_that("plot.caugi accepts circle_size for partial edges", {
+  cg <- caugi(A %o->% B, B %o-o% C, class = "UNKNOWN")
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # Test that custom circle_size is accepted
+  p <- plot(
+    cg,
+    edge_style = list(
+      partial = list(circle_size = 2.5)
+    )
+  )
+  expect_s7_class(p, caugi_plot)
+})
+
+test_that("plot.caugi with mixed edge types including partial", {
+  cg <- caugi(
+    A %-->% B,
+    B %o->% C,
+    C %o-o% D,
+    class = "UNKNOWN"
+  )
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # Test that mixed edge types render correctly
+  expect_s7_class(plot(cg), caugi_plot)
+})

--- a/vignettes/visualization.Rmd
+++ b/vignettes/visualization.Rmd
@@ -250,8 +250,34 @@ plot(
 Available edge style parameters:
 
 - **Appearance (passed to `gpar()`)**: `col`, `lwd`, `lty`, `alpha`, `fill`
-- **Geometry**: `arrow_size` (arrow length in mm)
+- **Geometry**: `arrow_size` (arrow length in mm), `circle_size` (radius of endpoint circles for partial edges in mm)
 - **Per-type options**: `directed`, `undirected`, `bidirected`, `partial`
+
+#### Partial Edges
+
+Partial edges (`o->` and `o-o`) are rendered with circles at their endpoints to indicate uncertainty about edge orientation. These edges appear in PAGs (Partial Ancestral Graphs). You can customize the circle size:
+
+```{r partial-edges}
+# Create a graph with partial edges (using UNKNOWN class since PAG not yet implemented)
+g <- caugi(
+  A %o->% B,
+  B %-->% C,
+  C %o-o% D,
+  class = "UNKNOWN"
+)
+
+# Customize circle size for partial edges
+plot(
+  g,
+  edge_style = list(
+    partial = list(
+      col = "purple",
+      lwd = 2,
+      circle_size = 2.5 # Larger circles (default is 1.5)
+    )
+  )
+)
+```
 
 ### Label Styling
 


### PR DESCRIPTION
Closes #139. Also adds new option for setting the circle size.

``` r
library(caugi)

cg <- caugi(
  A %o->% B,
  B %-->% C,
  C %o-o% D,
  D %---% E,
  E %<->% F,
  class = "UNKNOWN"
)

plot(cg)
```

![](https://i.imgur.com/7llsBjC.png)<!-- -->

<sup>Created on 2025-12-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>