### PR TITLE
Fix as_caugi to preserve undirected edges in bnlearn graphs (#148)

### DIFF
--- a/R/as_caugi.R
+++ b/R/as_caugi.R
@@ -349,7 +349,8 @@ S7::method(
     # Correct pcalg PAG code mapping:
     # 1 = circle, 2 = arrowhead, 3 = tail (codes refer to the COLUMN end)
     mark_sym <- function(k) {
-      switch(as.character(k),
+      switch(
+        as.character(k),
         "1" = "o", # circle
         "2" = ">", # arrowhead
         "3" = "-", # tail
@@ -400,7 +401,8 @@ S7::method(
           lj <- tmp
         }
 
-        glyph <- switch(paste0(lf, rt),
+        glyph <- switch(
+          paste0(lf, rt),
           "--" = "---",
           "->" = "-->",
           "-o" = "--o",
@@ -638,7 +640,8 @@ S7::method(
   }
 
   map_glyph <- function(s) {
-    switch(s,
+    switch(
+      s,
       "->" = "-->",
       "<->" = "<->",
       "--" = "---",

--- a/R/as_caugi.R
+++ b/R/as_caugi.R
@@ -349,8 +349,7 @@ S7::method(
     # Correct pcalg PAG code mapping:
     # 1 = circle, 2 = arrowhead, 3 = tail (codes refer to the COLUMN end)
     mark_sym <- function(k) {
-      switch(
-        as.character(k),
+      switch(as.character(k),
         "1" = "o", # circle
         "2" = ">", # arrowhead
         "3" = "-", # tail
@@ -401,8 +400,7 @@ S7::method(
           lj <- tmp
         }
 
-        glyph <- switch(
-          paste0(lf, rt),
+        glyph <- switch(paste0(lf, rt),
           "--" = "---",
           "->" = "-->",
           "-o" = "--o",
@@ -640,8 +638,7 @@ S7::method(
   }
 
   map_glyph <- function(s) {
-    switch(
-      s,
+    switch(s,
       "->" = "-->",
       "<->" = "<->",
       "--" = "---",
@@ -749,13 +746,18 @@ S7::method(
   if (collapse) {
     is_edge_symmetric(collapse_to)
 
-    has_rev <- (from != to) & match(pair_key, rev_key, nomatch = 0L) > 0L
-    keep_rep <- !duplicated(key) & (from == canon_from)
-    keep <- !has_rev | keep_rep
+    has_rev <- (from != to) & pair_key %in% rev_key
+    rep_idx <- has_rev & !duplicated(key)
 
-    from <- ifelse(has_rev & keep, canon_from, from)[keep]
-    to <- ifelse(has_rev & keep, canon_to, to)[keep]
-    edge <- ifelse(has_rev & keep, collapse_to, edge)[keep]
+    from[rep_idx] <- canon_from[rep_idx]
+    to[rep_idx] <- canon_to[rep_idx]
+    edge[rep_idx] <- collapse_to
+
+    keep <- !has_rev | rep_idx
+
+    from <- from[keep]
+    to <- to[keep]
+    edge <- edge[keep]
   }
 
   caugi(

--- a/tests/testthat/test-as_caugi.R
+++ b/tests/testthat/test-as_caugi.R
@@ -473,13 +473,20 @@ test_that("as_caugi with bnlearn with both directed and undirected edges and col
   bn <- bnlearn::empty.graph(nodes)
   bnlearn::arcs(bn) <- matrix(
     c(
-      "x", "v",
-      "x", "w",
-      "v", "x",
-      "v", "z",
-      "w", "x",
-      "w", "z",
-      "z", "s"
+      "x",
+      "v",
+      "x",
+      "w",
+      "v",
+      "x",
+      "v",
+      "z",
+      "w",
+      "x",
+      "w",
+      "z",
+      "z",
+      "s"
     ),
     ncol = 2,
     byrow = TRUE,
@@ -493,7 +500,7 @@ test_that("as_caugi with bnlearn with both directed and undirected edges and col
   expected <- data.table::data.table(
     from = c("v", "v", "w", "w", "z"),
     edge = c("---", "-->", "---", "-->", "-->"),
-    to   = c("x", "z", "x", "z", "s")
+    to = c("x", "z", "x", "z", "s")
   )
 
   data.table::setorder(actual, from, to, edge)

--- a/tests/testthat/test-as_caugi.R
+++ b/tests/testthat/test-as_caugi.R
@@ -463,3 +463,41 @@ test_that("as_caugi with bnlearn and collapse = TRUE", {
   expect_equal(nrow(cg@edges), 1L)
   expect_equal(unique(cg@edges$edge), "---")
 })
+
+test_that("as_caugi with bnlearn with both directed and undirected edges and collapse = TRUE", {
+  skip_if_not_installed("igraph")
+  skip_if_not_installed("bnlearn")
+
+  nodes <- c("x", "v", "w", "z", "s")
+
+  bn <- bnlearn::empty.graph(nodes)
+  bnlearn::arcs(bn) <- matrix(
+    c(
+      "x", "v",
+      "x", "w",
+      "v", "x",
+      "v", "z",
+      "w", "x",
+      "w", "z",
+      "z", "s"
+    ),
+    ncol = 2,
+    byrow = TRUE,
+    dimnames = list(NULL, c("from", "to"))
+  )
+
+  cg <- as_caugi(bn, class = "PDAG", collapse = TRUE)
+
+  actual <- edges(cg)
+
+  expected <- data.table::data.table(
+    from = c("v", "v", "w", "w", "z"),
+    edge = c("---", "-->", "---", "-->", "-->"),
+    to   = c("x", "z", "x", "z", "s")
+  )
+
+  data.table::setorder(actual, from, to, edge)
+  data.table::setorder(expected, from, to, edge)
+
+  expect_identical(actual, expected)
+})


### PR DESCRIPTION
This fixes the issue in #148 and adds a unit test to prevent it in the future.