### PR TITLE
feat: decompose graphs into components for plotting

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -118,7 +118,7 @@ n_ptr <- function(g) .Call(wrap__n_ptr, g)
 
 edges_ptr_df <- function(g) .Call(wrap__edges_ptr_df, g)
 
-compute_layout_ptr <- function(g, method) .Call(wrap__compute_layout_ptr, g, method)
+compute_layout_ptr <- function(g, method, packing_ratio) .Call(wrap__compute_layout_ptr, g, method, packing_ratio)
 
 compute_bipartite_layout_ptr <- function(g, partition, orientation) .Call(wrap__compute_bipartite_layout_ptr, g, partition, orientation)
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -40,6 +40,10 @@
 #'   * `"kamada-kawai"`: High-quality stress minimization (works with all edge
 #'     types)
 #'   * `"bipartite"`: Bipartite layout (requires `partition` parameter)
+#' @param packing_ratio Aspect ratio for packing disconnected components
+#'   (width/height). Default is the golden ratio (≈1.618) which works well with
+#'   widescreen displays. Use `1.0` for square grid, `2.0` for wider layouts,
+#'   `0.5` for taller layouts, `Inf` for single row, or `0.0` for single column.
 #' @param ... Additional arguments passed to the specific layout function.
 #'   For bipartite layouts, use `partition` (logical vector) and `orientation`
 #'   (`"rows"` or `"columns"`).
@@ -110,6 +114,7 @@ caugi_layout <- function(
     "kamada-kawai",
     "bipartite"
   ),
+  packing_ratio = 1.618034,
   ...
 ) {
   is_caugi(x, throw_error = TRUE)
@@ -139,7 +144,13 @@ caugi_layout <- function(
     "bipartite" = caugi_layout_bipartite
   )
 
-  layout_fn(x, ...)
+  # Call the layout function with packing_ratio parameter
+  if (method == "bipartite") {
+    # Bipartite doesn't use packing_ratio
+    layout_fn(x, ...)
+  } else {
+    layout_fn(x, packing_ratio = packing_ratio, ...)
+  }
 }
 
 #' Bipartite Graph Layout
@@ -249,6 +260,8 @@ caugi_layout_bipartite <- function(
 #' emphasize hierarchical structure and causal flow from top to bottom.
 #'
 #' @param x A `caugi` object. Must contain only directed edges.
+#' @param ... Ignored. For future extensibility.
+#' @inheritParams caugi_layout
 #'
 #' @returns A `data.frame` with columns `name`, `x`, and `y` containing node
 #'   names and their coordinates.
@@ -266,7 +279,7 @@ caugi_layout_bipartite <- function(
 #' \doi{10.1109/TSMC.1981.4308636}
 #'
 #' @export
-caugi_layout_sugiyama <- function(x) {
+caugi_layout_sugiyama <- function(x, packing_ratio = 1.618034, ...) {
   is_caugi(x, throw_error = TRUE)
 
   # Ensure graph is built
@@ -289,7 +302,7 @@ caugi_layout_sugiyama <- function(x) {
     )
   }
 
-  coords <- compute_layout_ptr(x@ptr, "sugiyama")
+  coords <- compute_layout_ptr(x@ptr, "sugiyama", packing_ratio)
 
   data.frame(
     name = nodes(x)[["name"]],
@@ -308,6 +321,8 @@ caugi_layout_sugiyama <- function(x) {
 #' deterministic results.
 #'
 #' @param x A `caugi` object.
+#' @inheritParams caugi_layout
+#' @param ... Ignored. For future extensibility.
 #'
 #' @returns A `data.frame` with columns `name`, `x`, and `y` containing node
 #'   names and their coordinates.
@@ -328,7 +343,11 @@ caugi_layout_sugiyama <- function(x) {
 #' 1129-1164. \doi{10.1002/spe.4380211102}
 #'
 #' @export
-caugi_layout_fruchterman_reingold <- function(x) {
+caugi_layout_fruchterman_reingold <- function(
+  x,
+  packing_ratio = 1.618034,
+  ...
+) {
   is_caugi(x, throw_error = TRUE)
 
   # Ensure graph is built
@@ -336,7 +355,7 @@ caugi_layout_fruchterman_reingold <- function(x) {
     x <- build(x)
   }
 
-  coords <- compute_layout_ptr(x@ptr, "fruchterman-reingold")
+  coords <- compute_layout_ptr(x@ptr, "fruchterman-reingold", packing_ratio)
 
   data.frame(
     name = nodes(x)[["name"]],
@@ -356,6 +375,8 @@ caugi_layout_fruchterman_reingold <- function(x) {
 #' produces deterministic results.
 #'
 #' @param x A `caugi` object.
+#' @inheritParams caugi_layout
+#' @param ... Ignored. For future extensibility.
 #'
 #' @returns A `data.frame` with columns `name`, `x`, and `y` containing node
 #'   names and their coordinates.
@@ -376,7 +397,7 @@ caugi_layout_fruchterman_reingold <- function(x) {
 #' \doi{10.1016/0020-0190(89)90102-6}
 #'
 #' @export
-caugi_layout_kamada_kawai <- function(x) {
+caugi_layout_kamada_kawai <- function(x, packing_ratio = 1.618034, ...) {
   is_caugi(x, throw_error = TRUE)
 
   # Ensure graph is built
@@ -384,7 +405,7 @@ caugi_layout_kamada_kawai <- function(x) {
     x <- build(x)
   }
 
-  coords <- compute_layout_ptr(x@ptr, "kamada-kawai")
+  coords <- compute_layout_ptr(x@ptr, "kamada-kawai", packing_ratio)
 
   data.frame(
     name = nodes(x)[["name"]],

--- a/man/caugi_layout.Rd
+++ b/man/caugi_layout.Rd
@@ -21,6 +21,7 @@ Systems, Man, and Cybernetics, 11(2), 109-125.
 caugi_layout(
   x,
   method = c("auto", "sugiyama", "fruchterman-reingold", "kamada-kawai", "bipartite"),
+  packing_ratio = 1.618034,
   ...
 )
 }
@@ -39,6 +40,11 @@ edge types)
 types)
 \item \code{"bipartite"}: Bipartite layout (requires \code{partition} parameter)
 }}
+
+\item{packing_ratio}{Aspect ratio for packing disconnected components
+(width/height). Default is the golden ratio (≈1.618) which works well with
+widescreen displays. Use \code{1.0} for square grid, \code{2.0} for wider layouts,
+\code{0.5} for taller layouts, \code{Inf} for single row, or \code{0.0} for single column.}
 
 \item{...}{Additional arguments passed to the specific layout function.
 For bipartite layouts, use \code{partition} (logical vector) and \code{orientation}

--- a/man/caugi_layout_fruchterman_reingold.Rd
+++ b/man/caugi_layout_fruchterman_reingold.Rd
@@ -9,10 +9,17 @@ force-directed placement. Software: Practice and Experience, 21(11),
 1129-1164. \doi{10.1002/spe.4380211102}
 }
 \usage{
-caugi_layout_fruchterman_reingold(x)
+caugi_layout_fruchterman_reingold(x, packing_ratio = 1.618034, ...)
 }
 \arguments{
 \item{x}{A \code{caugi} object.}
+
+\item{packing_ratio}{Aspect ratio for packing disconnected components
+(width/height). Default is the golden ratio (≈1.618) which works well with
+widescreen displays. Use \code{1.0} for square grid, \code{2.0} for wider layouts,
+\code{0.5} for taller layouts, \code{Inf} for single row, or \code{0.0} for single column.}
+
+\item{...}{Ignored. For future extensibility.}
 }
 \value{
 A \code{data.frame} with columns \code{name}, \code{x}, and \code{y} containing node

--- a/man/caugi_layout_kamada_kawai.Rd
+++ b/man/caugi_layout_kamada_kawai.Rd
@@ -9,10 +9,17 @@ undirected graphs. Information Processing Letters, 31(1), 7-15.
 \doi{10.1016/0020-0190(89)90102-6}
 }
 \usage{
-caugi_layout_kamada_kawai(x)
+caugi_layout_kamada_kawai(x, packing_ratio = 1.618034, ...)
 }
 \arguments{
 \item{x}{A \code{caugi} object.}
+
+\item{packing_ratio}{Aspect ratio for packing disconnected components
+(width/height). Default is the golden ratio (≈1.618) which works well with
+widescreen displays. Use \code{1.0} for square grid, \code{2.0} for wider layouts,
+\code{0.5} for taller layouts, \code{Inf} for single row, or \code{0.0} for single column.}
+
+\item{...}{Ignored. For future extensibility.}
 }
 \value{
 A \code{data.frame} with columns \code{name}, \code{x}, and \code{y} containing node

--- a/man/caugi_layout_sugiyama.Rd
+++ b/man/caugi_layout_sugiyama.Rd
@@ -10,10 +10,17 @@ Systems, Man, and Cybernetics, 11(2), 109-125.
 \doi{10.1109/TSMC.1981.4308636}
 }
 \usage{
-caugi_layout_sugiyama(x)
+caugi_layout_sugiyama(x, packing_ratio = 1.618034, ...)
 }
 \arguments{
 \item{x}{A \code{caugi} object. Must contain only directed edges.}
+
+\item{packing_ratio}{Aspect ratio for packing disconnected components
+(width/height). Default is the golden ratio (≈1.618) which works well with
+widescreen displays. Use \code{1.0} for square grid, \code{2.0} for wider layouts,
+\code{0.5} for taller layouts, \code{Inf} for single row, or \code{0.0} for single column.}
+
+\item{...}{Ignored. For future extensibility.}
 }
 \value{
 A \code{data.frame} with columns \code{name}, \code{x}, and \code{y} containing node

--- a/src/rust/src/graph/layout/components.rs
+++ b/src/rust/src/graph/layout/components.rs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: MIT
+//! Connected component detection and layout packing utilities.
+
+use crate::graph::CaugiGraph;
+/// Returns a vector where component[i] is the component ID for node i.
+pub fn detect_components(graph: &CaugiGraph) -> Vec<usize> {
+    let n = graph.n() as usize;
+    if n == 0 {
+        return Vec::new();
+    }
+
+    let mut component = vec![usize::MAX; n];
+    let mut current_component = 0;
+
+    for start in 0..n {
+        if component[start] != usize::MAX {
+            continue;
+        }
+
+        // BFS to find all nodes in this component
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(start);
+        component[start] = current_component;
+
+        while let Some(u) = queue.pop_front() {
+            // Get outgoing edges
+            let range = graph.row_range(u as u32);
+            for idx in range {
+                let v = graph.col_index[idx] as usize;
+                if component[v] == usize::MAX {
+                    component[v] = current_component;
+                    queue.push_back(v);
+                }
+            }
+
+            // For directed edges, also check incoming edges
+            // We need to traverse the entire CSR to find edges pointing to u
+            (0..n).for_each(|i| {
+                if component[i] == usize::MAX {
+                    let range = graph.row_range(i as u32);
+                    for idx in range {
+                        let j = graph.col_index[idx] as usize;
+                        if j == u {
+                            component[i] = current_component;
+                            queue.push_back(i);
+                        }
+                    }
+                }
+            });
+        }
+
+        current_component += 1;
+    }
+
+    component
+}
+
+/// Group nodes by component.
+/// Returns a vector of vectors, where each inner vector contains node indices in one component.
+pub fn group_by_component(components: &[usize]) -> Vec<Vec<usize>> {
+    if components.is_empty() {
+        return Vec::new();
+    }
+
+    let num_components = components.iter().max().map(|&x| x + 1).unwrap_or(0);
+    let mut groups = vec![Vec::new(); num_components];
+
+    for (node, &comp) in components.iter().enumerate() {
+        groups[comp].push(node);
+    }
+
+    groups
+}
+
+/// Bounding box for a component layout.
+#[derive(Debug, Clone, Copy)]
+struct BoundingBox {
+    min_x: f64,
+    max_x: f64,
+    min_y: f64,
+    max_y: f64,
+}
+
+impl BoundingBox {
+    fn width(&self) -> f64 {
+        self.max_x - self.min_x
+    }
+
+    fn height(&self) -> f64 {
+        self.max_y - self.min_y
+    }
+
+    fn from_coords(coords: &[(f64, f64)]) -> Self {
+        let mut bbox = BoundingBox {
+            min_x: f64::INFINITY,
+            max_x: f64::NEG_INFINITY,
+            min_y: f64::INFINITY,
+            max_y: f64::NEG_INFINITY,
+        };
+
+        for &(x, y) in coords {
+            bbox.min_x = bbox.min_x.min(x);
+            bbox.max_x = bbox.max_x.max(x);
+            bbox.min_y = bbox.min_y.min(y);
+            bbox.max_y = bbox.max_y.max(y);
+        }
+
+        bbox
+    }
+}
+
+/// A component layout with its node indices and coordinates.
+type ComponentLayout = (Vec<usize>, Vec<(f64, f64)>);
+
+/// A component layout enriched with bounding box and area information.
+type ComponentWithBBox = (Vec<usize>, Vec<(f64, f64)>, BoundingBox, f64);
+
+/// Pack multiple component layouts into a single layout.
+/// Components are arranged in a grid with target aspect ratio (width / height).
+/// Returns combined coordinates for all nodes in original order.
+///
+/// # Aspect Ratio
+/// - `1.0` = square grid (e.g., 9 components → 3×3)
+/// - `2.0` = prefer 2:1 width:height (e.g., 6 components → 3×2)
+/// - `0.5` = prefer 1:2 width:height (e.g., 6 components → 2×3)
+/// - `f64::INFINITY` = single row (horizontal)
+/// - `0.0` = single column (vertical)
+pub fn pack_component_layouts(
+    component_layouts: Vec<ComponentLayout>,
+    padding: f64,
+    aspect_ratio: f64,
+) -> Vec<(f64, f64)> {
+    if component_layouts.is_empty() {
+        return Vec::new();
+    }
+
+    // Single component - no packing needed
+    if component_layouts.len() == 1 {
+        let (nodes, coords) = &component_layouts[0];
+        let bbox = BoundingBox::from_coords(coords);
+        let mut result = vec![(0.0, 0.0); coords.len()];
+        for (i, &node_id) in nodes.iter().enumerate() {
+            let (x, y) = coords[i];
+            result[node_id] = (x - bbox.min_x, y - bbox.min_y);
+        }
+        return result;
+    }
+
+    let total_nodes = component_layouts.iter().map(|(nodes, _)| nodes.len()).sum();
+
+    // Compute bounding boxes and sort by size (largest first)
+    let mut components_with_bbox: Vec<ComponentWithBBox> = component_layouts
+        .into_iter()
+        .map(|(nodes, coords)| {
+            let bbox = BoundingBox::from_coords(&coords);
+            let area = bbox.width() * bbox.height();
+            (nodes, coords, bbox, area)
+        })
+        .collect();
+
+    components_with_bbox.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Calculate grid dimensions based on aspect ratio
+    let num_components = components_with_bbox.len();
+    let (cols, rows) = if aspect_ratio.is_infinite() {
+        // Horizontal: single row
+        (num_components, 1)
+    } else if aspect_ratio == 0.0 {
+        // Vertical: single column
+        (1, num_components)
+    } else {
+        // Grid with target aspect ratio
+        // aspect_ratio = width / height = cols / rows
+        // We want cols * rows >= num_components
+        // And cols / rows ≈ aspect_ratio
+        // So cols ≈ sqrt(num_components * aspect_ratio)
+        let cols = ((num_components as f64) * aspect_ratio).sqrt().ceil() as usize;
+        let cols = cols.max(1); // Ensure at least 1 column
+        let rows = num_components.div_ceil(cols);
+        (cols, rows)
+    };
+
+    // Calculate cell sizes (max width/height in each column/row)
+    let mut col_widths = vec![0.0_f64; cols];
+    let mut row_heights = vec![0.0_f64; rows];
+
+    for (idx, (_, _, bbox, _)) in components_with_bbox.iter().enumerate() {
+        let col = idx % cols;
+        let row = idx / cols;
+        col_widths[col] = col_widths[col].max(bbox.width());
+        row_heights[row] = row_heights[row].max(bbox.height());
+    }
+
+    // Calculate cell positions (cumulative with padding)
+    let mut col_positions = vec![0.0_f64; cols];
+    let mut row_positions = vec![0.0_f64; rows];
+
+    for i in 1..cols {
+        col_positions[i] = col_positions[i - 1] + col_widths[i - 1] + padding;
+    }
+
+    for i in 1..rows {
+        row_positions[i] = row_positions[i - 1] + row_heights[i - 1] + padding;
+    }
+
+    let mut result = vec![(0.0, 0.0); total_nodes];
+
+    for (idx, (nodes, coords, bbox, _)) in components_with_bbox.into_iter().enumerate() {
+        let col = idx % cols;
+        let row = idx / cols;
+
+        // Center component within its cell
+        let cell_x = col_positions[col];
+        let cell_y = row_positions[row];
+        let x_center_offset = (col_widths[col] - bbox.width()) / 2.0;
+        let y_center_offset = (row_heights[row] - bbox.height()) / 2.0;
+
+        for (i, &node_id) in nodes.iter().enumerate() {
+            let (x, y) = coords[i];
+            result[node_id] = (
+                x - bbox.min_x + cell_x + x_center_offset,
+                y - bbox.min_y + cell_y + y_center_offset,
+            );
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::edges::EdgeRegistry;
+    use crate::graph::builder::GraphBuilder;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_detect_components_single() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let cdir = reg.code_of("-->").unwrap();
+
+        // Single connected component: A --> B --> C
+        let mut b = GraphBuilder::new_with_registry(3, true, &reg);
+        b.add_edge(0, 1, cdir).unwrap();
+        b.add_edge(1, 2, cdir).unwrap();
+        let core = Arc::new(b.finalize().unwrap());
+
+        let components = detect_components(&core);
+        assert_eq!(components.len(), 3);
+        assert_eq!(components[0], components[1]);
+        assert_eq!(components[1], components[2]);
+    }
+
+    #[test]
+    fn test_detect_components_multiple() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let cdir = reg.code_of("-->").unwrap();
+
+        // Two components: A --> B and C --> D
+        let mut b = GraphBuilder::new_with_registry(4, true, &reg);
+        b.add_edge(0, 1, cdir).unwrap();
+        b.add_edge(2, 3, cdir).unwrap();
+        let core = Arc::new(b.finalize().unwrap());
+
+        let components = detect_components(&core);
+        assert_eq!(components.len(), 4);
+        assert_eq!(components[0], components[1]);
+        assert_eq!(components[2], components[3]);
+        assert_ne!(components[0], components[2]);
+    }
+
+    #[test]
+    fn test_detect_components_isolated_nodes() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let cdir = reg.code_of("-->").unwrap();
+
+        // A --> B, C (isolated), D (isolated)
+        let mut b = GraphBuilder::new_with_registry(4, true, &reg);
+        b.add_edge(0, 1, cdir).unwrap();
+        let core = Arc::new(b.finalize().unwrap());
+
+        let components = detect_components(&core);
+        assert_eq!(components.len(), 4);
+        assert_eq!(components[0], components[1]);
+        assert_ne!(components[0], components[2]);
+        assert_ne!(components[0], components[3]);
+        assert_ne!(components[2], components[3]);
+    }
+
+    #[test]
+    fn test_detect_components_empty() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let b = GraphBuilder::new_with_registry(0, true, &reg);
+        let core = Arc::new(b.finalize().unwrap());
+
+        let components = detect_components(&core);
+        assert!(components.is_empty());
+    }
+
+    #[test]
+    fn test_group_by_component() {
+        let components = vec![0, 0, 1, 1, 2];
+        let groups = group_by_component(&components);
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0], vec![0, 1]);
+        assert_eq!(groups[1], vec![2, 3]);
+        assert_eq!(groups[2], vec![4]);
+    }
+
+    #[test]
+    fn test_group_by_component_empty() {
+        let components: Vec<usize> = vec![];
+        let groups = group_by_component(&components);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn test_pack_component_layouts() {
+        // Two components with simple coordinates (will be packed in 2 columns, 1 row)
+        let comp1 = (vec![0, 1], vec![(0.0, 0.0), (1.0, 1.0)]);
+        let comp2 = (vec![2, 3], vec![(0.0, 0.0), (1.0, 1.0)]);
+
+        let result = pack_component_layouts(vec![comp1, comp2], 0.5, 1.0);
+
+        assert_eq!(result.len(), 4);
+        // All coordinates should be finite and non-negative
+        for &(x, y) in &result {
+            assert!(x.is_finite() && x >= 0.0);
+            assert!(y.is_finite() && y >= 0.0);
+        }
+        // Components should be separated (second component has larger x coords)
+        assert!(result[2].0 > result[1].0);
+    }
+
+    #[test]
+    fn test_pack_component_layouts_grid() {
+        // Four components should be arranged in a 2x2 grid
+        let comp1 = (vec![0, 1], vec![(0.0, 0.0), (1.0, 1.0)]);
+        let comp2 = (vec![2, 3], vec![(0.0, 0.0), (1.0, 1.0)]);
+        let comp3 = (vec![4, 5], vec![(0.0, 0.0), (1.0, 1.0)]);
+        let comp4 = (vec![6, 7], vec![(0.0, 0.0), (1.0, 1.0)]);
+
+        let result = pack_component_layouts(vec![comp1, comp2, comp3, comp4], 0.5, 1.0);
+
+        assert_eq!(result.len(), 8);
+        // All coordinates should be valid
+        for &(x, y) in &result {
+            assert!(x.is_finite());
+            assert!(y.is_finite());
+        }
+        // Should have components in both x and y dimensions
+        let max_x = result.iter().map(|&(x, _)| x).fold(0.0, f64::max);
+        let max_y = result.iter().map(|&(_, y)| y).fold(0.0, f64::max);
+        assert!(max_x > 0.0);
+        assert!(max_y > 0.0);
+    }
+
+    #[test]
+    fn test_pack_component_layouts_empty() {
+        let result = pack_component_layouts(vec![], 0.5, 1.0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_pack_component_layouts_single() {
+        let comp = (vec![0, 1, 2], vec![(0.0, 0.0), (1.0, 0.5), (0.5, 1.0)]);
+        let result = pack_component_layouts(vec![comp], 0.5, 1.0);
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], (0.0, 0.0));
+        assert_eq!(result[1], (1.0, 0.5));
+        assert_eq!(result[2], (0.5, 1.0));
+    }
+
+    #[test]
+    fn test_pack_horizontal() {
+        let comp1 = (vec![0, 1], vec![(0.0, 0.0), (1.0, 1.0)]);
+        let comp2 = (vec![2, 3], vec![(0.0, 0.0), (1.0, 1.0)]);
+
+        let result = pack_component_layouts(vec![comp1, comp2], 0.5, f64::INFINITY);
+
+        assert_eq!(result.len(), 4);
+        // Should be in a single row (similar y values)
+        let y_vals: Vec<f64> = result.iter().map(|&(_, y)| y).collect();
+        let y_range = y_vals.iter().fold(0.0_f64, |a, &b| a.max(b))
+            - y_vals.iter().fold(f64::INFINITY, |a, &b| a.min(b));
+        assert!(y_range <= 1.1); // Allow some tolerance
+    }
+
+    #[test]
+    fn test_pack_vertical() {
+        let comp1 = (vec![0, 1], vec![(0.0, 0.0), (1.0, 1.0)]);
+        let comp2 = (vec![2, 3], vec![(0.0, 0.0), (1.0, 1.0)]);
+
+        let result = pack_component_layouts(vec![comp1, comp2], 0.5, 0.0);
+
+        assert_eq!(result.len(), 4);
+        // Should be in a single column (similar x values)
+        let x_vals: Vec<f64> = result.iter().map(|&(x, _)| x).collect();
+        let x_range = x_vals.iter().fold(0.0_f64, |a, &b| a.max(b))
+            - x_vals.iter().fold(f64::INFINITY, |a, &b| a.min(b));
+        assert!(x_range <= 1.1); // Allow some tolerance
+    }
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1016,14 +1016,14 @@ fn latent_project_ptr(g: ExternalPtr<GraphView>, latents: Integers) -> ExternalP
 // ── Layout ────────────────────────────────────────────────────────────────────
 
 #[extendr]
-fn compute_layout_ptr(g: ExternalPtr<GraphView>, method: &str) -> Robj {
+fn compute_layout_ptr(g: ExternalPtr<GraphView>, method: &str, packing_ratio: f64) -> Robj {
     use graph::layout::{compute_layout, LayoutMethod};
     use std::str::FromStr;
 
     let layout_method = LayoutMethod::from_str(method).unwrap_or_else(|e| throw_r_error(e));
 
-    let coords =
-        compute_layout(g.as_ref().core(), layout_method).unwrap_or_else(|e| throw_r_error(e));
+    let coords = compute_layout(g.as_ref().core(), layout_method, packing_ratio)
+        .unwrap_or_else(|e| throw_r_error(e));
 
     let n = coords.len();
     let mut x = Vec::with_capacity(n);

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -451,3 +451,54 @@ test_that("plot.caugi with mixed edge types including partial", {
   # Test that mixed edge types render correctly
   expect_s7_class(plot(cg), caugi_plot)
 })
+
+test_that("caugi_layout handles disconnected components", {
+  # Single isolated node
+  cg1 <- caugi(
+    A %-->% B + C,
+    D
+  )
+
+  layout1 <- caugi_layout(cg1, method = "fruchterman-reingold")
+  expect_s3_class(layout1, "data.frame")
+  expect_equal(nrow(layout1), 4L)
+  expect_true(all(is.finite(layout1$x)))
+  expect_true(all(is.finite(layout1$y)))
+
+  # Multiple disconnected components
+  cg2 <- caugi(
+    A %-->% B,
+    C %-->% D,
+    E
+  )
+
+  layout2 <- caugi_layout(cg2, method = "kamada-kawai")
+  expect_s3_class(layout2, "data.frame")
+  expect_equal(nrow(layout2), 5L)
+  expect_true(all(is.finite(layout2$x)))
+  expect_true(all(is.finite(layout2$y)))
+
+  # Sugiyama with disconnected components
+  layout3 <- caugi_layout(cg1, method = "sugiyama")
+  expect_s3_class(layout3, "data.frame")
+  expect_equal(nrow(layout3), 4L)
+  expect_true(all(is.finite(layout3$x)))
+  expect_true(all(is.finite(layout3$y)))
+})
+
+test_that("plot.caugi renders disconnected components", {
+  cg <- caugi(
+    A %-->% B + C,
+    D,
+    E %-->% F
+  )
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # Should work with all layout methods
+  expect_s7_class(plot(cg, layout = "fruchterman-reingold"), caugi_plot)
+  expect_s7_class(plot(cg, layout = "kamada-kawai"), caugi_plot)
+  expect_s7_class(plot(cg, layout = "sugiyama"), caugi_plot)
+  expect_s7_class(plot(cg, layout = "auto"), caugi_plot)
+})


### PR DESCRIPTION
Fixes #151

This is still a little rough. The margins of some of the plots are suboptimal. Also, I'm using regular grid packing for the components here, but maybe we should align with baseline instead or something. Not sure.

Thoughts, @frederikfabriciusbjerre and @BjarkeHautop ?

``` r
library(caugi)

cg <- caugi(
  A %-->% B + C,
  D
)
plot(cg, layout = "fruchterman-reingold")
```

![](https://i.imgur.com/WuVWJwK.png)<!-- -->

``` r
plot(cg, layout = "kamada-kawai")
```

![](https://i.imgur.com/Tze4VQU.png)<!-- -->

``` r

cg <- caugi(
  A %-->% B + C,
  D,
  E
)
plot(cg, layout = "sugiyama")
```

![](https://i.imgur.com/bH5Sxa4.png)<!-- -->

``` r
plot(cg, layout = "fruchterman-reingold")
```

![](https://i.imgur.com/z36sbmg.png)<!-- -->

``` r

# Different packing ratios, default is golden ratio
plot(cg, layout = "kamada-kawai", packing_ratio = 1)
```

![](https://i.imgur.com/bwvCwzJ.png)<!-- -->

``` r

plot(cg, layout = "kamada-kawai", packing_ratio = 0)
```

![](https://i.imgur.com/AIPWouC.png)<!-- -->

``` r

plot(cg, layout = "kamada-kawai", packing_ratio = Inf)
```

![](https://i.imgur.com/L9a6syG.png)<!-- -->

<sup>Created on 2026-01-05 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>