### PR TITLE
ci: modify codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,17 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
 ignore:
   - "R/zzz.R"


### PR DESCRIPTION
The codecov settings are too harsh, I think. Missing 1 line in code coverage has it report a failure. Also, I personally think the commenting is annoying, but let's discuss that.

This PR uses the default code coverage settings from `usethis::use_coverage()`.