### PR TITLE
fix: wrap `write_graphml()` in example in `\dontrun{}`

### DIFF
--- a/R/format-graphml.R
+++ b/R/format-graphml.R
@@ -56,7 +56,9 @@ caugi_graphml <- S7::new_class(
 #' cat(graphml@content)
 #'
 #' # Write to file
+#' \dontrun{
 #' write_graphml(cg, "graph.graphml")
+#' }
 #'
 #' @family export
 #' @export

--- a/man/to_graphml.Rd
+++ b/man/to_graphml.Rd
@@ -40,7 +40,9 @@ graphml <- to_graphml(cg)
 cat(graphml@content)
 
 # Write to file
+\dontrun{
 write_graphml(cg, "graph.graphml")
+}
 
 }
 \seealso{


### PR DESCRIPTION
Currently, the example is writing to a file, which generates a CRAN note. This PR fixes this.