### PR TITLE
Improve speed of .update_caugi inplace=FALSE

### DIFF
--- a/R/verbs.R
+++ b/R/verbs.R
@@ -428,13 +428,8 @@ remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
       built = FALSE,
       simple = s$simple,
       class = s$class,
-      name_index_map = fastmap::fastmap()
+      name_index_map = s$name_index_map$clone()
     )
-    # populate name_index_map with keys from original
-    for (k in s$name_index_map$keys()) {
-      state_copy$name_index_map$set(k, s$name_index_map$get(k))
-    }
-
     cg_copy <- caugi(state = state_copy)
 
     # reuse the in-place path on the copy


### PR DESCRIPTION
The fix I did in PR #167 rebuilt the fastmap. Saw they had a clone method, which is faster. Here is a benchmark from before

```{r}
cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y)

remove_wrapper <- function() {
  new_cg <- remove_nodes(cg, "U", inplace = FALSE)
  invisible(new_cg)
}

system.time({
  for (i in seq_len(1e5)) {
    remove_wrapper()
  }
})
> user  system elapsed 
> 118.78    5.87  127.29 
```

Here is after the change:

```{r}
cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y)

remove_wrapper <- function() {
  new_cg <- remove_nodes(cg, "U", inplace = FALSE)
  invisible(new_cg)
}

system.time({
  for (i in seq_len(1e5)) {
    remove_wrapper()
  }
})
> user  system elapsed 
> 80.79    5.33   89.14
```

(I also verified it is safe by checking `cg` nodes didn't change)