### PR TITLE
Refactor edges() and nodes() to method dispatch

### DIFF
--- a/R/queries.R
+++ b/R/queries.R
@@ -498,6 +498,8 @@ is_mag <- function(cg, force_check = FALSE) {
 #'
 #' @param cg A `caugi` object.
 #'
+#' @param ... Additional arguments (currently unused).
+#'
 #' @returns A `data.table` with a `name` column.
 #'
 #' @rdname nodes
@@ -535,6 +537,8 @@ V <- nodes # igraph notation
 #' @title Get edges of a `caugi`.
 #'
 #' @param cg A `caugi` object.
+#'
+#' @param ... Additional arguments (currently unused).
 #'
 #' @rdname edges
 #'

--- a/man/edges.Rd
+++ b/man/edges.Rd
@@ -11,6 +11,8 @@ E(cg, ...)
 }
 \arguments{
 \item{cg}{A \code{caugi} object.}
+
+\item{...}{Additional arguments (currently unused).}
 }
 \value{
 A \code{data.table} with columns \code{from}, \code{edge}, and \code{to}.

--- a/man/nodes.Rd
+++ b/man/nodes.Rd
@@ -14,6 +14,8 @@ V(cg, ...)
 }
 \arguments{
 \item{cg}{A \code{caugi} object.}
+
+\item{...}{Additional arguments (currently unused).}
 }
 \value{
 A \code{data.table} with a \code{name} column.


### PR DESCRIPTION
This change makes `nodes()` and `edges()` into S7 generics with method dispatch.

The motivation is to avoid potential namespace clashes: `nodes()` and `edges()` are common function names in other packages. Without method dispatch, it would be more difficult to use caugi alongside other packages that define functions/methods with the same names. Now, `nodes(cg)` and `edges(cg)` will work for caugi objects while still allowing other packages to define their own dispatch.