### PR TITLE
Normalize output coordinates for `kamada_kawai` and `fruchterman_reingold` layouts, and add rounding

### DIFF
--- a/src/rust/src/graph/layout/normalize.rs
+++ b/src/rust/src/graph/layout/normalize.rs
@@ -35,10 +35,14 @@ pub fn normalize_to_unit_box(coords: &mut [(f64, f64)]) {
         return;
     }
 
+    // Offsets to center the smaller dimension
+    let offset_x = if width < scale { (scale - width) / 2.0 } else { 0.0 };
+    let offset_y = if height < scale { (scale - height) / 2.0 } else { 0.0 };
+
     // Translate and scale
     for coord in coords.iter_mut() {
-        coord.0 = (coord.0 - min_x) / scale;
-        coord.1 = (coord.1 - min_y) / scale;
+        coord.0 = (coord.0 - min_x + offset_x) / scale;
+        coord.1 = (coord.1 - min_y + offset_y) / scale;
     }
 }
 


### PR DESCRIPTION
Currently, `kamada_kawai` and `fruchterman_reingold` return very small, unnormalized coordinates, which are hard to read and inconvenient to work with. Internally, the coordinates are normalized, but the returned coordinates are not.

This PR in the first commit makes them normalized in the Rust code, and the 2nd commit rounds all algorithm layout coordinates to 3 digits in the R code.

Here is the current output:

``` r
library(caugi)

cg <- caugi(A %-->% B + C)

# These are normalized
caugi_layout_sugiyama(cg)
#>   name   x y
#> 1    A 0.5 0
#> 2    B 1.0 1
#> 3    C 0.0 1
caugi_layout_bipartite(cg)
#>   name x   y
#> 1    A 1 0.5
#> 2    B 0 0.0
#> 3    C 0 1.0
tiers_vector <- c(A = 1, B = 2, C = 2)
caugi_layout_tiered(cg, tiers = tiers_vector)
#>   name x   y tier
#> 1    A 0 0.5    0
#> 2    B 1 0.0    1
#> 3    C 1 1.0    1

# These are not normalized
caugi_layout_kamada_kawai(cg)
#>   name         x            y
#> 1    A 0.4999548 2.672678e-02
#> 2    B 1.0000000 1.611850e-06
#> 3    C 0.0000000 0.000000e+00
caugi_layout_fruchterman_reingold(cg)
#>   name   x            y
#> 1    A 0.5 1.992323e-04
#> 2    B 1.0 0.000000e+00
#> 3    C 0.0 2.336590e-11
```

<sup>Created on 2026-01-26 with [reprex v2.1.1.9000](https://reprex.tidyverse.org)</sup>

With the 1st commit `kamada_kawai` and `fruchterman_reingold` are now like this

```{r}
> caugi_layout_kamada_kawai(cg)
  name         x         y
1    A 0.0000000 0.5005187
2    B 1.0000000 0.9996239
3    C 0.9990578 0.0000000
> caugi_layout_fruchterman_reingold(cg)
  name         x         y
1    A 0.0000000 0.5306945
2    B 1.0000000 0.9786023
3    C 0.9451489 0.0000000
```

And with the 2nd commit with rounding, they look like this:

```{r}
> caugi_layout_kamada_kawai(cg)
  name     x     y
1    A 0.000 0.501
2    B 1.000 1.000
3    C 0.999 0.000
> caugi_layout_fruchterman_reingold(cg)
  name     x     y
1    A 0.000 0.531
2    B 1.000 0.979
3    C 0.945 0.000
```
