### PR TITLE
feat: add `asp` parameter to `plot()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # caugi (development version)
 
+- Add `asp` parameter to `plot()` for controlling aspect ratio. When `asp = 1`,
+  the plot respects equal units on both axes, preserving the layout
+  coordinates. Works like base R's `asp` parameter (y/x aspect ratio).
+
 # caugi 1.0.0
 
 ## New Features

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -86,6 +86,13 @@ no title is displayed.}
 \code{fontfamily}, \code{cex}
 }}
 
+\item{asp}{Numeric value for the y/x aspect ratio. If \code{NA} (default), the
+aspect ratio is automatically determined to fill the available space.
+Use \code{asp = 1} to ensure that one unit on the x-axis equals one unit on
+the y-axis, which respects the layout coordinates. Values other than 1
+will stretch the plot accordingly (e.g., \code{asp = 2} makes the y-axis
+twice as tall as the x-axis for the same data range).}
+
 \item{outer_margin}{Grid unit specifying outer margin around the plot.
 Default is \code{grid::unit(2, "mm")}.}
 
@@ -149,6 +156,9 @@ plot(
   main = "My Graph",
   title_style = list(fontsize = 18, col = "blue", fontface = "italic")
 )
+
+# Respect aspect ratio (1:1)
+plot(cg, asp = 1)
 
 }
 \seealso{

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -603,3 +603,25 @@ test_that("plot.caugi renders disconnected components", {
   expect_s7_class(plot(cg, layout = "sugiyama"), caugi_plot)
   expect_s7_class(plot(cg, layout = "auto"), caugi_plot)
 })
+
+test_that("plot.caugi asp parameter works", {
+  cg <- caugi(A %-->% B + C, B %-->% D, class = "DAG")
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # asp = NULL should work (automatic aspect ratio)
+  expect_s7_class(plot(cg, asp = NULL), caugi_plot)
+
+  # asp = NA should work (automatic aspect ratio)
+  expect_s7_class(plot(cg, asp = NA), caugi_plot)
+
+  # asp = 1 should work (equal aspect ratio)
+  expect_s7_class(plot(cg, asp = 1), caugi_plot)
+
+  # asp = 2 should work (y-axis twice as tall)
+  expect_s7_class(plot(cg, asp = 2), caugi_plot)
+
+  # asp = 0.5 should work (x-axis twice as wide)
+  expect_s7_class(plot(cg, asp = 0.5), caugi_plot)
+})


### PR DESCRIPTION
This PR adds a `asp` parameter to `plot()`, which works exactly like the base R `asp` parameter of `plot()` does. Setting `asp = 1` means that the aspect ratio in the layout from `caugi_layout()` is respected.

Related to #194

What do you think, @BjarkeHautop ?

``` r
library(caugi)

cg <- caugi(
  A %-->% B + C,
  B %-->% D,
  C %-->% D,
  class = "DAG"
)

plot(cg, main = "Default (no asp)")
```

![](https://i.imgur.com/odQQApb.png)<!-- -->

``` r

plot(cg, asp = 1, main = "asp = 1")
```

![](https://i.imgur.com/eyLLNSY.png)<!-- -->

``` r

plot(cg, asp = 2, main = "asp = 2")
```

![](https://i.imgur.com/xbS2KfO.png)<!-- -->

``` r

plot(cg, asp = 0.5, main = "asp = 0.5")
```

![](https://i.imgur.com/KcKcNfn.png)<!-- -->

``` r

cg <- caugi(A %-->% B + C)
plot(cg, asp = 1, layout = "fr", main = "asp = 1, layout = fr")
```

![](https://i.imgur.com/MiEXRAO.png)<!-- -->

<sup>Created on 2026-01-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>