### PR TITLE
fix: stop parenthesis in mutate_caugi

### DIFF
--- a/R/operations.R
+++ b/R/operations.R
@@ -203,14 +203,16 @@ mutate_caugi <- function(cg, class) {
   )
 
   if (!is_mutation_possible) {
-    stop(paste0(
-      "Cannot convert caugi of class '",
-      old_class,
-      "' to '",
-      class,
-      "'.",
+    stop(
+      paste0(
+        "Cannot convert caugi of class '",
+        old_class,
+        "' to '",
+        class,
+        "'."
+      ),
       call. = FALSE
-    ))
+    )
   } else {
     return(caugi(
       nodes = nodes(cg),


### PR DESCRIPTION
The `call. = FALSE` call is given inside of `paste0()` instead of `stop()` currently. This fixes that.