### PR TITLE
Fix vignette name for pkgdown site

### DIFF
--- a/vignettes/caugi.Rmd
+++ b/vignettes/caugi.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Get started"
+title: "caugi"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Get started}
+  %\VignetteIndexEntry{caugi}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
For pkgdown, it expects a vignette of the package name to make a "Get started" entry on the site. I.e., the bar at the top will now look like this
<img width="406" height="44" alt="image" src="https://github.com/user-attachments/assets/6170e51e-e26e-45ab-a394-4012e77f584b" />
