### PR TITLE
refactor: deprecate `all` in `districts()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,11 @@
 - Fixed a bug causing `plot()` to use incorrect layout if node names were not
   in the same order as in the graph object (#198).
 
+## Deprecations
+
+- The parameter `all` in `districts()` has been deprecated. Just use
+  `districts()` without arguments to get all districts.
+
 # caugi 1.0.0
 
 ## New Features

--- a/R/queries.R
+++ b/R/queries.R
@@ -1286,15 +1286,15 @@ spouses <- function(cg, nodes = NULL, index = NULL) {
 #'
 #' @description Get districts (c-components) for all nodes, or for selected
 #' nodes in an ADMG/AG. A district is a maximal set of nodes connected via
-#' bidirected edges.
+#' bidirected edges. If both `nodes` and `index` are `NULL`, returns all districts in the graph.
 #'
 #' @param cg A `caugi` object of class ADMG or AG.
 #' @param nodes Optional character vector of node names. If supplied, returns
 #' district(s) containing these nodes.
 #' @param index Optional numeric vector of 1-based node indices. If supplied,
 #' returns district(s) containing these indices.
-#' @param all Optional logical. If `TRUE`, return all districts explicitly.
-#' Cannot be combined with `nodes` or `index`.
+#' @param all DEPRECATED (If `TRUE`, return all districts explicitly.
+#' Cannot be combined with `nodes` or `index`.)
 #'
 #' @returns If all districts are requested: a list of character vectors, one per
 #' district. If `nodes`/`index` are supplied: either a character vector (single
@@ -1316,15 +1316,28 @@ spouses <- function(cg, nodes = NULL, index = NULL) {
 #' @concept queries
 #'
 #' @export
-districts <- function(cg, nodes = NULL, index = NULL, all = NULL) {
+districts <- function(cg, nodes = NULL, index = NULL, all) {
   is_caugi(cg, throw_error = TRUE)
 
-  if (!is.null(all) && (!is.logical(all) || length(all) != 1L || is.na(all))) {
-    stop("`all` must be TRUE, FALSE, or NULL.", call. = FALSE)
+  if (!missing(all)) {
+    # TODO: Remove in a future major release
+    warning(
+      "`all` argument is deprecated and will be removed in a future version. ",
+      "To get all districts, simply call `districts(cg)` without `nodes` or `index`.",
+      call. = FALSE
+    )
+
+    if (
+      !is.null(all) && (!is.logical(all) || length(all) != 1L || is.na(all))
+    ) {
+      stop("`all` must be TRUE, FALSE, or NULL.", call. = FALSE)
+    }
+  } else {
+    all <- is.null(nodes) && is.null(index)
   }
 
-  nodes_supplied <- !missing(nodes) && !is.null(nodes)
-  index_supplied <- !missing(index) && !is.null(index)
+  nodes_supplied <- !is.null(nodes)
+  index_supplied <- !is.null(index)
 
   if (nodes_supplied && index_supplied) {
     stop("Supply either `nodes` or `index`, not both.", call. = FALSE)

--- a/man/districts.Rd
+++ b/man/districts.Rd
@@ -4,7 +4,7 @@
 \alias{districts}
 \title{Get districts (c-components) of an ADMG or AG}
 \usage{
-districts(cg, nodes = NULL, index = NULL, all = NULL)
+districts(cg, nodes = NULL, index = NULL, all)
 }
 \arguments{
 \item{cg}{A \code{caugi} object of class ADMG or AG.}
@@ -15,8 +15,8 @@ district(s) containing these nodes.}
 \item{index}{Optional numeric vector of 1-based node indices. If supplied,
 returns district(s) containing these indices.}
 
-\item{all}{Optional logical. If \code{TRUE}, return all districts explicitly.
-Cannot be combined with \code{nodes} or \code{index}.}
+\item{all}{DEPRECATED (If \code{TRUE}, return all districts explicitly.
+Cannot be combined with \code{nodes} or \code{index}.)}
 }
 \value{
 If all districts are requested: a list of character vectors, one per
@@ -26,7 +26,7 @@ target) or a named list of character vectors (multiple targets).
 \description{
 Get districts (c-components) for all nodes, or for selected
 nodes in an ADMG/AG. A district is a maximal set of nodes connected via
-bidirected edges.
+bidirected edges. If both \code{nodes} and \code{index} are \code{NULL}, returns all districts in the graph.
 }
 \examples{
 cg <- caugi(

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -612,19 +612,6 @@ test_that("districts supports all, nodes, and index modes", {
   expect_named(by_index, c("A", "D"))
   expect_setequal(by_index$A, c("A", "B", "C"))
   expect_identical(by_index$D, "D")
-
-  all_explicit <- districts(cg, all = TRUE)
-  expect_equal(length(all_explicit), length(all_d))
-  expect_true(any(vapply(
-    all_explicit,
-    function(x) setequal(x, c("A", "B", "C")),
-    logical(1)
-  )))
-  expect_true(any(vapply(
-    all_explicit,
-    function(x) identical(x, "D"),
-    logical(1)
-  )))
 })
 
 test_that("districts validates argument combinations", {
@@ -634,8 +621,6 @@ test_that("districts validates argument combinations", {
     districts(cg, nodes = "A", index = 1L),
     "either `nodes` or `index`"
   )
-  expect_error(districts(cg, all = TRUE, nodes = "A"), "cannot be combined")
-  expect_error(districts(cg, all = FALSE), "requires `nodes` or `index`")
   expect_error(districts(cg, index = 0), "out of range")
   expect_error(districts(cg, nodes = c("A", NA_character_)), "without NA")
 })


### PR DESCRIPTION
The `all` argument serves no real purpose. Why would someone want to set it to `FALSE`? This is already implicit if either `nodes` or `index` is provided. We should just keep the implicit behavior of returning all districts if both `nodes` and `index` are `NULL`. So we deprecate it. The deprecation warning will only hit anyone who explicitly uses the `all` flag, which is probably very rare.