### PR TITLE
Deprecate `inplace` parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,10 @@
     and `@ptr` now warn on access and return `NULL`.
   - Deprecated compatibility constructor arguments `build` and `state` in
     `caugi()` now warn and are ignored.
+- Deprecated `inplace` parameter in verb functions (`add_edges()`, `remove_edges()`,
+  `set_edges()`, `add_nodes()`, `remove_nodes()`). All graph modifications now use
+  copy-on-write semantics for consistency with R conventions. The parameter is
+  ignored with a deprecation warning.
 - Added `all.equal` and `compare_proxy` methods for caugi objects to support
   graph-content comparison in tests.
 - Add `asp` parameter to `plot()` for controlling aspect ratio. When `asp = 1`,

--- a/R/verbs.R
+++ b/R/verbs.R
@@ -18,8 +18,8 @@
 #' @param edge Character vector of edge types. Default is `NULL`.
 #' @param to Character vector of target node names. Default is `NULL`.
 #' @param name Character vector of node names. Default is `NULL`.
-#' @param inplace Logical, whether to modify the graph inplace or not.
-#' If `FALSE` (default), a copy of the `caugi` is made and modified.
+#' @param inplace DEPRECATED This parameter is deprecated and will be ignored.
+#' Graphs are always modified via copy-on-write.
 #'
 #' @returns The updated `caugi`.
 #'
@@ -75,6 +75,14 @@ add_edges <- function(
   to = NULL,
   inplace = FALSE
 ) {
+  if (!missing(inplace)) {
+    warning(
+      "The `inplace` argument is deprecated and will be ignored. ",
+      "Graphs are always modified via copy-on-write.",
+      call. = FALSE
+    )
+  }
+
   calls <- as.list(substitute(list(...)))[-1L]
   has_expr <- length(calls) > 0L
   has_vec <- !(is.null(from) && is.null(edge) && is.null(to))
@@ -93,7 +101,7 @@ add_edges <- function(
   edges <- .get_edges(from, edge, to, calls)
 
   # update via helper and return
-  .update_caugi(cg, edges = edges, action = "add", inplace = inplace)
+  .update_caugi(cg, edges = edges, action = "add")
 }
 
 #' @describeIn caugi_verbs Remove edges.
@@ -106,6 +114,14 @@ remove_edges <- function(
   to = NULL,
   inplace = FALSE
 ) {
+  if (!missing(inplace)) {
+    warning(
+      "The `inplace` argument is deprecated and will be ignored. ",
+      "Graphs are always modified via copy-on-write.",
+      call. = FALSE
+    )
+  }
+
   calls <- as.list(substitute(list(...)))[-1L]
   has_expr <- length(calls) > 0L
   has_vec <- !(is.null(from) && is.null(edge) && is.null(to))
@@ -153,13 +169,12 @@ remove_edges <- function(
     return(.update_caugi(
       cg,
       edges = pairs,
-      action = "remove",
-      inplace = inplace
+      action = "remove"
     ))
   }
 
   edges <- .get_edges(from, edge, to, calls, simple = cg@simple)
-  .update_caugi(cg, edges = edges, action = "remove", inplace = inplace)
+  .update_caugi(cg, edges = edges, action = "remove")
 }
 
 
@@ -173,6 +188,14 @@ set_edges <- function(
   to = NULL,
   inplace = FALSE
 ) {
+  if (!missing(inplace)) {
+    warning(
+      "The `inplace` argument is deprecated and will be ignored. ",
+      "Graphs are always modified via copy-on-write.",
+      call. = FALSE
+    )
+  }
+
   calls <- as.list(substitute(list(...)))[-1L]
   has_expr <- length(calls) > 0L
   has_vec <- !(is.null(from) && is.null(edge) && is.null(to))
@@ -189,7 +212,7 @@ set_edges <- function(
 
   edges <- .get_edges(from, edge, to, calls)
 
-  .update_caugi(cg, edges = edges, action = "replace", inplace = inplace)
+  .update_caugi(cg, edges = edges, action = "replace")
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -199,23 +222,39 @@ set_edges <- function(
 #' @describeIn caugi_verbs Add nodes.
 #' @export
 add_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
+  if (!missing(inplace)) {
+    warning(
+      "The `inplace` argument is deprecated and will be ignored. ",
+      "Graphs are always modified via copy-on-write.",
+      call. = FALSE
+    )
+  }
+
   calls <- as.list(substitute(list(...)))[-1L]
   nodes <- .get_nodes(name, calls)
   if (!nrow(nodes)) {
     return(cg)
   }
-  .update_caugi(cg, nodes = nodes, action = "add", inplace = inplace)
+  .update_caugi(cg, nodes = nodes, action = "add")
 }
 
 #' @describeIn caugi_verbs Remove nodes.
 #' @export
 remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
+  if (!missing(inplace)) {
+    warning(
+      "The `inplace` argument is deprecated and will be ignored. ",
+      "Graphs are always modified via copy-on-write.",
+      call. = FALSE
+    )
+  }
+
   calls <- as.list(substitute(list(...)))[-1L]
   nodes <- .get_nodes(name, calls)
   if (!nrow(nodes)) {
     return(cg)
   }
-  .update_caugi(cg, nodes = nodes, action = "remove", inplace = inplace)
+  .update_caugi(cg, nodes = nodes, action = "remove")
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -345,7 +384,7 @@ remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
 #' @param edges A `data.frame` with columns `from`, `edge`, `to` for edges to
 #' add/remove.
 #' @param action One of `"add"`, `"remove"`, or `"replace"`.
-#' @param inplace Logical, whether to modify the graph inplace or not.
+#' @param inplace DEPRECATED Ignored. Kept for backward compatibility.
 #'
 #' @importFrom data.table `%chin%`
 #'
@@ -359,6 +398,14 @@ remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
   action = c("add", "remove", "replace"),
   inplace = FALSE
 ) {
+  if (!missing(inplace)) {
+    warning(
+      "The `inplace` argument is deprecated and will be ignored. ",
+      "Graphs are always modified via copy-on-write.",
+      call. = FALSE
+    )
+  }
+
   action <- match.arg(action)
   session <- cg@session
 
@@ -377,11 +424,7 @@ remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
     }
 
     new_nodes <- unique(c(current_nodes, edges$from, edges$to))
-    target_session <- if (isTRUE(inplace)) {
-      session
-    } else {
-      rs_clone(session)
-    }
+    target_session <- rs_clone(session)
 
     if (
       length(new_nodes) != length(current_nodes) ||
@@ -407,9 +450,6 @@ remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
       rs_set_class(target_session, resolved_class)
     }
 
-    if (isTRUE(inplace)) {
-      return(cg)
-    }
     return(caugi(.session = target_session))
   }
 
@@ -447,18 +487,8 @@ remove_nodes <- function(cg, ..., name = NULL, inplace = FALSE) {
     current_nodes <- unique(current_nodes)
     current_edges <- unique(current_edges)
   }
-  if (isTRUE(inplace)) {
-    .sync_session_inplace(
-      session = session,
-      node_names = current_nodes,
-      edges_dt = current_edges,
-      simple = current_simple,
-      class = current_class
-    )
-    return(cg)
-  }
 
-  # Copy-on-write path: clone then sync clone.
+  # Copy-on-write: clone then sync clone
   cloned_session <- rs_clone(session)
   .sync_session_inplace(
     session = cloned_session,

--- a/man/caugi_verbs.Rd
+++ b/man/caugi_verbs.Rd
@@ -31,8 +31,8 @@ or nodes to add using unquoted names, vectors via \code{c()}, or \code{+} compos
 
 \item{to}{Character vector of target node names. Default is \code{NULL}.}
 
-\item{inplace}{Logical, whether to modify the graph inplace or not.
-If \code{FALSE} (default), a copy of the \code{caugi} is made and modified.}
+\item{inplace}{DEPRECATED This parameter is deprecated and will be ignored.
+Graphs are always modified via copy-on-write.}
 
 \item{name}{Character vector of node names. Default is \code{NULL}.}
 }

--- a/man/dot-update_caugi.Rd
+++ b/man/dot-update_caugi.Rd
@@ -22,7 +22,7 @@ add/remove.}
 
 \item{action}{One of \code{"add"}, \code{"remove"}, or \code{"replace"}.}
 
-\item{inplace}{Logical, whether to modify the graph inplace or not.}
+\item{inplace}{DEPRECATED Ignored. Kept for backward compatibility.}
 }
 \value{
 The updated \code{caugi} object.

--- a/tests/testthat/test-verbs.R
+++ b/tests/testthat/test-verbs.R
@@ -256,11 +256,14 @@ test_that("verbs do not modify object for remove_nodes", {
   expect_equal(nrow(edges_new_object), 2L)
 })
 
-test_that("inplace = TRUE modifies object for remove_nodes", {
+test_that("inplace parameter issues deprecation warning for remove_nodes", {
   cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y)
-  remove_nodes(cg, "U", inplace = TRUE)
-  expect_equal(cg@nodes, data.table::data.table(name = c("Z", "X", "Y")))
-  expect_equal(nrow(cg@edges), 2L)
+  expect_warning(
+    result <- remove_nodes(cg, "U", inplace = TRUE),
+    "The `inplace` argument is deprecated"
+  )
+  # Verify it returns a new object despite inplace = TRUE
+  expect_false(identical(result@session, cg@session))
 })
 
 test_that("verbs do not modify object for add_nodes", {
@@ -282,10 +285,14 @@ test_that("verbs do not modify object for add_nodes", {
   expect_equal(edges_new_object, edges_before)
 })
 
-test_that("inplace = TRUE modifies object for add_nodes", {
+test_that("inplace parameter issues deprecation warning for add_nodes", {
   cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y)
-  add_nodes(cg, "W", inplace = TRUE)
-  expect_true("W" %in% cg@nodes$name)
+  expect_warning(
+    result <- add_nodes(cg, "W", inplace = TRUE),
+    "The `inplace` argument is deprecated"
+  )
+  # Verify it returns a new object despite inplace = TRUE
+  expect_false(identical(result@session, cg@session))
 })
 
 test_that("verbs do not modify object for remove_edges", {
@@ -302,10 +309,14 @@ test_that("verbs do not modify object for remove_edges", {
   expect_equal(nrow(edges_new_object), 3L)
 })
 
-test_that("inplace = TRUE modifies object for remove_edges", {
+test_that("inplace parameter issues deprecation warning for remove_edges", {
   cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y)
-  remove_edges(cg, from = "U", to = "X", inplace = TRUE)
-  expect_equal(nrow(cg@edges), 3L)
+  expect_warning(
+    result <- remove_edges(cg, from = "U", to = "X", inplace = TRUE),
+    "The `inplace` argument is deprecated"
+  )
+  # Verify it returns a new object despite inplace = TRUE
+  expect_false(identical(result@session, cg@session))
 })
 
 test_that("verbs do not modify object for add_edges", {
@@ -322,10 +333,14 @@ test_that("verbs do not modify object for add_edges", {
   expect_equal(nrow(edges_new_object), 5L)
 })
 
-test_that("inplace = TRUE modifies object for add_edges", {
+test_that("inplace parameter issues deprecation warning for add_edges", {
   cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y)
-  add_edges(cg, Z %-->% U, inplace = TRUE)
-  expect_equal(nrow(cg@edges), 5L)
+  expect_warning(
+    result <- add_edges(cg, Z %-->% U, inplace = TRUE),
+    "The `inplace` argument is deprecated"
+  )
+  # Verify it returns a new object despite inplace = TRUE
+  expect_false(identical(result@session, cg@session))
 })
 
 test_that("verbs do not modify object for set_edges", {
@@ -343,24 +358,32 @@ test_that("verbs do not modify object for set_edges", {
   expect_true("---" %in% edges_new_object$edge)
 })
 
-test_that("inplace = TRUE modifies object for set_edges", {
+test_that("inplace parameter issues deprecation warning for set_edges", {
   cg <- caugi(Z %-->% X %-->% Y, U %-->% X + Y, class = "PDAG")
-  set_edges(cg, U %---% X, inplace = TRUE)
-  expect_true("---" %in% cg@edges$edge)
+  expect_warning(
+    result <- set_edges(cg, U %---% X, inplace = TRUE),
+    "The `inplace` argument is deprecated"
+  )
+  # Verify it returns a new object despite inplace = TRUE
+  expect_false(identical(result@session, cg@session))
 })
 
-test_that("inplace = TRUE mutates shared references", {
-  cg <- caugi(A %-->% B, class = "DAG")
-  alias <- cg
-  add_nodes(cg, C, inplace = TRUE)
-  expect_true("C" %in% alias@nodes$name)
-})
-
-test_that("non-inplace updates clone session and isolate aliases", {
+test_that("copy-on-write semantics isolate references", {
   cg <- caugi(A %-->% B, class = "DAG")
   alias <- cg
 
-  out <- add_nodes(cg, C, inplace = FALSE)
+  # Without inplace, should create new session
+  out <- add_nodes(cg, C)
+  expect_false(identical(cg@session, out@session))
+  expect_false("C" %in% cg@nodes$name)
+  expect_true("C" %in% out@nodes$name)
+})
+
+test_that("updates clone session and isolate aliases", {
+  cg <- caugi(A %-->% B, class = "DAG")
+  alias <- cg
+
+  out <- add_nodes(cg, C)
 
   expect_false(identical(cg@session, out@session))
   expect_false("C" %in% alias@nodes$name)


### PR DESCRIPTION
The `inplace` parameter serves no real purpose after the Rust internal refactoring. This PR deprecates it and removes the logic around it.