### PR TITLE
Error on empty graph

### DIFF
--- a/R/plot-core.R
+++ b/R/plot-core.R
@@ -150,6 +150,10 @@ S7::method(plot, caugi) <- function(
 ) {
   is_caugi(x, throw_error = TRUE)
 
+  if (is_empty_caugi(x)) {
+    stop("Cannot plot an empty graph (0 nodes).", call. = FALSE)
+  }
+
   stopifnot(
     is.null(asp) ||
       is.na(asp) ||

--- a/R/plot-grobs.R
+++ b/R/plot-grobs.R
@@ -55,9 +55,11 @@ make_tiers <- function(
   }
 
   # Normalize to 0-indexed
-  min_tier <- min(assignments)
-  if (min_tier > 0) {
-    assignments <- assignments - min_tier
+  if (length(assignments) > 0) {
+    min_tier <- min(assignments)
+    if (min_tier > 0) {
+      assignments <- assignments - min_tier
+    }
   }
 
   # Extract components

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -888,6 +888,15 @@ test_that("plot-grobs internal branches are covered", {
   expect_equal(length(c2$children), 3L)
 })
 
+test_that("plotting empty graph gives clear error", {
+  cg_empty <- caugi(class = "DAG")
+
+  expect_error(
+    plot(cg_empty),
+    "Cannot plot an empty graph \\(0 nodes\\)\\."
+  )
+})
+
 test_that("plot layout validation branch is covered", {
   cg <- caugi(
     from = LETTERS[1:7],


### PR DESCRIPTION
Throw an error on passing empty graphs to the plotting functionality. Right now the user gets cryptic errors because plotting obviously fails when it's empty, but we can do better.