### PR TITLE
Always use DEPRECATED in doc and clarify doc slightly

### DIFF
--- a/R/caugi.R
+++ b/R/caugi.R
@@ -45,8 +45,9 @@
 #' It will default to `"UNKNOWN"` if no match is found.
 #' @param .session For internal use. Build a graph by supplying a
 #' pre-constructed session pointer from Rust.
-#' @param build Deprecated.
-#' @param state Deprecated. Replaced by `.session`.
+#' @param build DEPRECATED. The graph is always built lazily, so this argument is ignored.
+#' Can use [build()] to force lazy compilation if desired.
+#' @param state DEPRECATED. Replaced by `.session`.
 #'
 #' @returns A `caugi` S7 object containing the nodes, edges, and a
 #' pointer to the underlying Rust graph structure.

--- a/R/format-caugi.R
+++ b/R/format-caugi.R
@@ -88,7 +88,7 @@ write_caugi <- function(x, path, comment = NULL, tags = NULL) {
 #' Reads a caugi graph from a file in the native caugi JSON format.
 #'
 #' @param path Character string specifying the file path.
-#' @param lazy Deprecated, no longer necessary. Logical indicating whether to lazily read the graph.
+#' @param lazy DEPRECATED, no longer necessary. The graph is always built lazily, so this argument is ignored.
 #'
 #' @returns A `caugi` object.
 #'
@@ -201,8 +201,8 @@ caugi_serialize <- function(x, comment = NULL, tags = NULL) {
 #' This is a lower-level function; consider using `read_caugi()` for
 #' reading from files.
 #'
+#' @inheritParams read_caugi
 #' @param json Character string containing the JSON representation.
-#' @param lazy Deprecated, no longer necessary. Logical indicating whether to lazily deserialize the graph.
 #'
 #' @returns A `caugi` object.
 #'

--- a/man/caugi.Rd
+++ b/man/caugi.Rd
@@ -47,7 +47,8 @@ from another \code{caugi} object, \code{cg}.}
 the function will throw an error if the input contains parallel edges or
 self-loops.}
 
-\item{build}{Deprecated.}
+\item{build}{DEPRECATED. The graph is always built lazily, so this argument is ignored.
+Can use \code{\link[=build]{build()}} to force lazy compilation if desired.}
 
 \item{class}{Character; one of \code{"AUTO"}, \code{"DAG"}, \code{"UG"}, \code{"PDAG"}, \code{"ADMG"},
 \code{"AG"}, or \code{"UNKNOWN"}. \code{"AUTO"} will automatically pick the appropriate
@@ -55,7 +56,7 @@ class based on the first match in the order of \code{"DAG"}, \code{"UG"}, \code{
 \code{"ADMG"}, and \code{"AG"}.
 It will default to \code{"UNKNOWN"} if no match is found.}
 
-\item{state}{Deprecated. Replaced by \code{.session}.}
+\item{state}{DEPRECATED. Replaced by \code{.session}.}
 
 \item{.session}{For internal use. Build a graph by supplying a
 pre-constructed session pointer from Rust.}

--- a/man/caugi_deserialize.Rd
+++ b/man/caugi_deserialize.Rd
@@ -9,7 +9,7 @@ caugi_deserialize(json, lazy)
 \arguments{
 \item{json}{Character string containing the JSON representation.}
 
-\item{lazy}{Deprecated, no longer necessary. Logical indicating whether to lazily deserialize the graph.}
+\item{lazy}{DEPRECATED, no longer necessary. The graph is always built lazily, so this argument is ignored.}
 }
 \value{
 A \code{caugi} object.

--- a/man/read_caugi.Rd
+++ b/man/read_caugi.Rd
@@ -9,7 +9,7 @@ read_caugi(path, lazy)
 \arguments{
 \item{path}{Character string specifying the file path.}
 
-\item{lazy}{Deprecated, no longer necessary. Logical indicating whether to lazily read the graph.}
+\item{lazy}{DEPRECATED, no longer necessary. The graph is always built lazily, so this argument is ignored.}
 }
 \value{
 A \code{caugi} object.


### PR DESCRIPTION
Previously, we swapped between Deprecated and DEPRECATED. I don't really have a preference for either, but since all upper case was used the most, I went with that everywhere. Also, slightly clarify the documentation of some deprecated args.

Fixes item 4 of #241.