### PR TITLE
Add seed to generate_graph()

### DIFF
--- a/R/simulation.R
+++ b/R/simulation.R
@@ -9,6 +9,7 @@
 #' @param p Numeric in `[0,1]`. Probability of edge creation. Exactly one of
 #' `m` or `p` must be supplied.
 #' @param class "DAG" or "CPDAG".
+#' @param seed Optional integer; random seed for reproducibility.
 #'
 #' @returns The sampled `caugi` object.
 #'
@@ -23,7 +24,13 @@
 #' @concept simulation
 #'
 #' @export
-generate_graph <- function(n, m = NULL, p = NULL, class = c("DAG", "CPDAG")) {
+generate_graph <- function(
+  n,
+  m = NULL,
+  p = NULL,
+  class = c("DAG", "CPDAG"),
+  seed = NULL
+) {
   class <- match.arg(class)
   n <- as.integer(n)
   if (length(n) != 1L || n <= 0L) {
@@ -31,6 +38,9 @@ generate_graph <- function(n, m = NULL, p = NULL, class = c("DAG", "CPDAG")) {
   }
   if (xor(is.null(m), is.null(p)) == FALSE) {
     stop("Supply exactly one of m or p", call. = FALSE)
+  }
+  if (!is.null(seed)) {
+    set.seed(seed)
   }
 
   tot <- as.integer(n * (n - 1L) / 2L)

--- a/man/generate_graph.Rd
+++ b/man/generate_graph.Rd
@@ -4,7 +4,7 @@
 \alias{generate_graph}
 \title{Generate a \code{caugi} using Erdős-Rényi.}
 \usage{
-generate_graph(n, m = NULL, p = NULL, class = c("DAG", "CPDAG"))
+generate_graph(n, m = NULL, p = NULL, class = c("DAG", "CPDAG"), seed = NULL)
 }
 \arguments{
 \item{n}{Integer >= 0. Number of nodes in the graph.}
@@ -16,6 +16,8 @@ of \code{m} or \code{p} must be supplied.}
 \code{m} or \code{p} must be supplied.}
 
 \item{class}{"DAG" or "CPDAG".}
+
+\item{seed}{Optional integer; random seed for reproducibility.}
 }
 \value{
 The sampled \code{caugi} object.

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -106,6 +106,17 @@ test_that("CPDAG generation preserves sampled skeleton from DAG branch", {
   expect_true(is_cpdag(cpdag))
 })
 
+test_that("generate_graph with seed produces reproducible CPDAGs", {
+  cpdag1 <- generate_graph(10, m = 14L, class = "CPDAG", seed = 1405)
+  cpdag2 <- generate_graph(10, m = 14L, class = "CPDAG", seed = 1405)
+
+  expect_identical(
+    edges(cpdag1),
+    edges(cpdag2)
+  )
+})
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # ─────────────────────────── simulate_data tests ──────────────────────────────
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a seed to `generate_graph()` just like `simulate_data` has. Closes #245.