### PR TITLE
Fix broken tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,8 @@ Suggests:
     rextendr,
     rmarkdown,
     testthat,
-    waldo
+    waldo,
+    withr
 VignetteBuilder:
     knitr
 Config/rextendr/version: 0.4.2

--- a/tests/testthat/test-as_caugi.R
+++ b/tests/testthat/test-as_caugi.R
@@ -603,10 +603,6 @@ test_that("class-specific branches for optional backends are covered", {
     as_caugi(obj_tidy, class = "PAG"),
     "PAG class is not supported for tidygraph objects."
   )
-  expect_error(
-    as_caugi(obj_tidy, class = "DAG"),
-    "there is no package called"
-  )
 
   g_dagitty <- dagitty::dagitty("dag { A -> B }")
   expect_error(

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -43,6 +43,7 @@ test_that("print method respects max_nodes", {
 })
 
 test_that("print method with many edges shows truncation", {
+  withr::local_options(width = 40) # mock small console width
   # Create a graph with enough edges to trigger automatic truncation
   cg <- caugi(
     A %-->% B + C + D + E + G + H + I + J + K + L + M + N + O + P + Q,


### PR DESCRIPTION
Removes the test that expects an error "there is no package called", since I can't make that trigger (and it's not from our codebase)? When I run `as_caugi(obj_tidy)` I get this:

```r
> as_caugi(obj_tidy, class = "DAG")
Error in UseMethod("as.igraph") : 
  no applicable method for 'as.igraph' applied to an object of class "tidygraph"
Called from: tidygraph::as.igraph(x)
```

Mocked the console width in the print with truncation test, so it works even if the user has a large console size (like me). Hence, I added withr as a suggested dependency to do this.

Closes #242.
