### PR TITLE
Add workflow for benchmark

### DIFF
--- a/.github/workflows/benchmark.R
+++ b/.github/workflows/benchmark.R
@@ -24,12 +24,12 @@ test_node_index_new <- sample(n, 1)
 test_node_name_new <- paste0("V", test_node_index_new)
 
 bench_result <- bench::mark(
-  parents(cg, test_node_name),
-  children(cg, test_node_name),
-  ancestors(cg, test_node_name),
-  descendants(cg, test_node_name),
-  subgraph(cg, test_node_name),
-  {
+  parents = parents(cg, test_node_name),
+  children = children(cg, test_node_name),
+  ancestors = ancestors(cg, test_node_name),
+  descendants = descendants(cg, test_node_name),
+  subgraph = subgraph(cg, test_node_name),
+  d_seperated = {
     valid_adjustment_set <- adjustment_set(cg, test_node_name, test_node_name_new, type="backdoor")
     d_separated(cg, test_node_name, test_node_name_new, valid_adjustment_set)
   },

--- a/.github/workflows/benchmark.R
+++ b/.github/workflows/benchmark.R
@@ -1,0 +1,40 @@
+library(optparse)
+library(caugi)
+
+option_list <- list(
+  make_option(c("--output"), type="character", default="pr_time.rds",
+              help="RDS file to save benchmark results"),
+  make_option(c("--branch-name"), type="character", default="PR branch",
+              help="Name of branch for messages")
+)
+opt <- parse_args(OptionParser(option_list=option_list))
+
+set.seed(1405)
+n <- 1000
+p <- 0.25
+
+cat(sprintf("Running benchmark on %s...\n", opt$branch_name))
+
+cg <- generate_graph(n, p, class="DAG")
+build(cg)
+
+test_node_index <- sample(n, 1)
+test_node_name <- paste0("V", test_node_index)
+test_node_index_new <- sample(n, 1)
+test_node_name_new <- paste0("V", test_node_index_new)
+
+bench_result <- bench::mark(
+  parents(cg, test_node_name),
+  children(cg, test_node_name),
+  ancestors(cg, test_node_name),
+  descendants(cg, test_node_name),
+  subgraph(cg, test_node_name),
+  {
+    valid_adjustment_set <- adjustment_set(cg, test_node_name, test_node_name_new, type="backdoor")
+    d_separated(cg, test_node_name, test_node_name_new, valid_adjustment_set)
+  },
+  check = FALSE
+)
+
+saveRDS(bench_result, opt$output)
+cat(sprintf("%s benchmark done, results saved to %s\n", opt$branch_name, opt$output))

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -51,11 +51,11 @@ jobs:
             PR_total_time = pr$total_time,
             Main_median = main$median,
             Main_total_time = main$total_time,
-            Slowdown_percent_median = slowdown_median
+            Slowdown_percent_median = as.numeric(slowdown_median)
           )
           
           cat("\n=== Benchmark Comparison ===\n")
-          print(result_table, row.names = FALSE)
+          print(result_table, row.names = FALSE, width = Inf)
           
           if (any(slowdown_median >= 20)) {
             cat("\nERROR: PR branch is >=20% (median time) slower than main for at least one benchmark entry\n")

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,68 @@
+name: benchmark
+
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - name: Install dependencies
+        run: Rscript -e 'install.packages(c("remotes", "bench", "caugi", "optparse", "tibble"))'
+
+      - name: Install PR branch package
+        run: Rscript -e 'remotes::install_local(".", upgrade="never")'
+
+      - name: Run benchmark on PR branch
+        run: |
+          Rscript .github/workflows/benchmark.R
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          path: main_branch
+
+      - name: Run benchmark on main branch
+        run: |
+          Rscript .github/workflows/benchmark.R --output main_time.rds
+
+      - name: Compare results
+        run: |
+          Rscript -e '
+          pr <- readRDS("pr_time.rds")
+          main <- readRDS("main_time.rds")
+          
+          slowdown_median <- (pr$median - main$median) / main$median * 100
+          
+          # Make a table
+          result_table <- tibble::tibble(
+            Benchmark = seq_along(pr$median),
+            PR_median = pr$median,
+            PR_total_time = pr$total_time,
+            Main_median = main$median,
+            Main_total_time = main$total_time,
+            Slowdown_percent_median = slowdown_median
+          )
+          
+          cat("\n=== Benchmark Comparison ===\n")
+          print(result_table, row.names = FALSE)
+          
+          if (any(slowdown_median >= 20)) {
+            cat("\nERROR: PR branch is >=20% (median time) slower than main for at least one benchmark entry\n")
+            stop("Benchmark check failed")
+          } else {
+            cat("\nBenchmark check passed: PR is not more than 20% (median time) slower than main\n")
+          }
+          '

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,7 +46,7 @@ jobs:
           
           # Make a table
           result_table <- tibble::tibble(
-            Benchmark = seq_along(pr$median),
+            Benchmark = names(bench_result$expression),
             PR_median = pr$median,
             PR_total_time = pr$total_time,
             Main_median = main$median,

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -46,7 +46,7 @@ jobs:
           
           # Make a table
           result_table <- tibble::tibble(
-            Benchmark = names(bench_result$expression),
+            Benchmark = names(pr$expression),
             PR_median = pr$median,
             PR_total_time = pr$total_time,
             Main_median = main$median,


### PR DESCRIPTION
Related to the discussion on Discord.

This adds a workflow that essentially just runs the relevant code from the performance article on PR and main.

It prints a table to compare the output of `bench::mark()` and it fails if any of the benchmarked functions have a median time that is at least 20% slower (fairly arbitrary, but I observed a 10% difference at one point, so it needs to be more than that to avoid false positives).