### PR TITLE
Performance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # caugi (development version)
 
+## Improvements
+
+- Improved performance of all queries. Speedups are more significant on larger graphs,
+but even on small graphs, queries are roughly 5× faster.
+
+
 # caugi 1.1.0
 
 ## New Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Improvements
 
 - Improved performance of all queries. Speedups are more significant on larger graphs,
-but even on small graphs, queries are roughly 5× faster.
+but even on small graphs, queries are roughly 5x faster.
 
 
 # caugi 1.1.0

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -58,6 +58,8 @@ rs_graph_class <- function(session) .Call(wrap__rs_graph_class, session)
 
 rs_names <- function(session) .Call(wrap__rs_names, session)
 
+rs_names_subset <- function(session, indicies) .Call(wrap__rs_names_subset, session, indicies)
+
 rs_index_of <- function(session, name) .Call(wrap__rs_index_of, session, name)
 
 rs_indices_of <- function(session, names) .Call(wrap__rs_indices_of, session, names)

--- a/R/queries.R
+++ b/R/queries.R
@@ -1668,18 +1668,16 @@ subgraph <- function(cg, nodes = NULL, index = NULL) {
 #'
 #' @keywords internal
 .getter_output <- function(cg, idx0, nodes) {
-  nm <- cg@nodes$name
   to_names <- function(ix0) {
     if (length(ix0) == 0L) {
       return(NULL)
     }
-    nm[ix0 + 1L]
+    rs_names_subset(cg@session, as.integer(ix0))
   }
 
   # faster check than doing is.null and length == 1, since length(NULL) == 0
   if (length(nodes) <= 1L && length(idx0) == 1L) {
-    ix <- idx0[[1L]]
-    return(to_names(ix))
+    return(to_names(idx0[[1L]]))
   }
 
   out <- lapply(idx0, to_names)

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -794,6 +794,16 @@ fn rs_names(session: ExternalPtr<GraphSession>) -> Strings {
 }
 
 #[extendr]
+fn rs_names_subset(session: ExternalPtr<GraphSession>, indices: Vec<i32>) -> Strings {
+    let names = session.as_ref().names();
+
+    indices
+        .iter()
+        .map(|&i| names[i as usize].as_str())
+        .collect()
+}
+
+#[extendr]
 fn rs_index_of(session: ExternalPtr<GraphSession>, name: &str) -> Robj {
     match session.as_ref().index_of(name) {
         Some(idx) => (idx as i32).into_robj(),
@@ -1503,6 +1513,7 @@ extendr_module! {
     fn rs_class;
     fn rs_graph_class;
     fn rs_names;
+    fn rs_names_subset;
     fn rs_index_of;
     fn rs_indices_of;
     fn rs_edges_df;

--- a/vignettes/articles/performance.Rmd
+++ b/vignettes/articles/performance.Rmd
@@ -109,7 +109,7 @@ bm_parents_children <- bench::mark(
 plot(bm_parents_children)
 ```
 
-As you can see, `bnlearn` performs best for this particular example.
+As you can see, `caugi` alongside `bnlearn` performs the best for this particular example.
 In our next experiment, however, we will examine if this
 extends to different graph sizes and densities, by parameterizing
 our benchmark over `n` and `p`. Note that we adjust `p` as a function
@@ -192,7 +192,8 @@ plot_parameterized_benchmark <- function(bm) {
 plot_parameterized_benchmark(bm_parents_children_np)
 ```
 
-For ancestors and descendants, we see that `caugi` outperforms all other packages by a several magnitudes, except for `igraph`, which it still beats, but by a smaller margin:
+For ancestors and descendants, we see that `caugi` outperforms all other packages by a several magnitudes,
+except for `igraph`, which it still beats, but by a smaller margin:
 
 ```{r benchmark-an-de}
 #| fig-cap: "Benchmarking ancestors/descendants queries for different packages."
@@ -244,9 +245,12 @@ bm_dsep <- bench::mark(
 plot(bm_dsep)
 ```
 
+We see that `caugi` again outperforms the other packages by a large margin.
+
 #### Subgraph (building)
 
-Here we see an example of where the frontloading hurts performance. When we build a subgraph, we have to rebuild the entire `caugi` graph object. Here, we see that while `caugi` outperforms other packages for queries (except for parents/children for `bnlearn`), it is slower for building the graph objects themselves, which shows in the subgraph benchmark:
+Here we see an example of where the frontloading hurts performance. When we build a subgraph, we have to rebuild the entire `caugi` graph object. Here, we see that while `caugi` outperforms other packages for queries, it is slower for building the graph
+object itself compared to `igraph`, as seen below:
 
 ```{r benchmark-subgraph}
 #| fig-cap: "Benchmarking subgraph extraction for different packages."


### PR DESCRIPTION
Fixes #258. Implements `rs_names_subset()` from the issue, since on my (slower) work laptop, it seemed a tiny bit slower/equal speed to use the list approach. It also feels like it shouldn't be needed to even do what we do here now, since we still recompute the node names. But fixing that requires a bit more thinking and some more Rust code. So, I just went with the simplest fix for now.

Profiling the code now, and the time is now spent on `rs_names_subset()`, so improving it would provide some relevant speed-up.
<img width="1143" height="168" alt="image" src="https://github.com/user-attachments/assets/905259f2-c8c9-47f8-979a-5145dd68e8cf" />

Also updated the performance article, which can be seen here [performance.html](https://github.com/user-attachments/files/26305738/performance.html).

It's now the fastest in everything except rebuilding (subgraph).