### PR TITLE
performance: improve subgraph and build performance

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -28,3 +28,9 @@ gadjid = ['dep:gadjid']
 [profile.release]
 lto = true
 codegen-units = 1
+
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package.caugi]
+opt-level = 3

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -28,9 +28,3 @@ gadjid = ['dep:gadjid']
 [profile.release]
 lto = true
 codegen-units = 1
-
-[profile.dev]
-opt-level = 1
-
-[profile.dev.package.caugi]
-opt-level = 3

--- a/src/rust/src/graph/builder.rs
+++ b/src/rust/src/graph/builder.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 //! GraphBuilder: collects edges and emits class-agnostic CSR.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
+use rustc_hash::FxHashSet;
+
 use super::error::BuilderError;
+use super::session::EdgeBuffer;
 use super::{CaugiGraph, RegistrySnapshot};
 use crate::edges::{EdgeRegistry, EdgeSpec};
 
@@ -14,8 +16,8 @@ pub struct GraphBuilder {
     simple: bool,
     specs: Arc<[EdgeSpec]>,
     rows: Vec<Vec<HalfEdge>>,
-    seen: HashSet<(u32, u32, u8, bool)>,
-    pair_seen: HashSet<(u32, u32)>,
+    seen: FxHashSet<(u32, u32, u8, bool)>,
+    pair_seen: FxHashSet<(u32, u32)>,
 }
 
 /// Encodes the position of this endpoint in the edge: 0 = tail position, 1 = head position.
@@ -73,22 +75,36 @@ impl GraphBuilder {
             simple,
             specs,
             rows: vec![Vec::new(); n_us],
-            seen: HashSet::new(),
-            pair_seen: HashSet::new(),
+            seen: FxHashSet::default(),
+            pair_seen: FxHashSet::default(),
         }
     }
 
     /// Create a new builder from an existing registry snapshot.
     /// This is more efficient when the snapshot already exists (e.g., in GraphSession).
     pub fn new_from_snapshot(n: u32, simple: bool, snapshot: Arc<RegistrySnapshot>) -> Self {
+        Self::new_from_snapshot_with_capacity(n, simple, snapshot, 0)
+    }
+
+    /// Create a new builder with pre-reserved hash set capacity for expected edge count.
+    pub fn new_from_snapshot_with_capacity(
+        n: u32,
+        simple: bool,
+        snapshot: Arc<RegistrySnapshot>,
+        expected_edges: usize,
+    ) -> Self {
         let n_us = n as usize;
         Self {
             n,
             simple,
             specs: Arc::clone(&snapshot.specs),
             rows: vec![Vec::new(); n_us],
-            seen: HashSet::new(),
-            pair_seen: HashSet::new(),
+            seen: FxHashSet::with_capacity_and_hasher(expected_edges, Default::default()),
+            pair_seen: if simple {
+                FxHashSet::with_capacity_and_hasher(expected_edges, Default::default())
+            } else {
+                FxHashSet::default()
+            },
         }
     }
 
@@ -117,10 +133,9 @@ impl GraphBuilder {
             return Err(BuilderError::SelfLoop { node: u });
         }
 
-        let spec: EdgeSpec = self
+        let spec = self
             .specs
             .get(etype as usize)
-            .cloned()
             .ok_or(BuilderError::InvalidEdgeCode { code: etype })?;
 
         if self.simple {
@@ -159,6 +174,82 @@ impl GraphBuilder {
         });
     }
 
+    /// Build CSR directly from a trusted EdgeBuffer, skipping per-edge validation.
+    ///
+    /// This is safe when edges have already been validated (e.g., from a session
+    /// that validated them on insertion). Skips hash-set duplicate detection and
+    /// bounds checks, going straight to CSR construction.
+    pub fn build_from_edge_buffer(
+        n: u32,
+        simple: bool,
+        edges: &EdgeBuffer,
+        snapshot: Arc<RegistrySnapshot>,
+    ) -> Result<CaugiGraph, String> {
+        let n_us = n as usize;
+        let edge_count = edges.len();
+
+        // Pre-allocate rows with estimated capacity (2 halves per edge, spread across n nodes).
+        let avg_degree = if n_us > 0 {
+            (2 * edge_count / n_us).max(1)
+        } else {
+            0
+        };
+        let mut rows: Vec<Vec<HalfEdge>> = (0..n_us)
+            .map(|_| Vec::with_capacity(avg_degree))
+            .collect();
+
+        for i in 0..edge_count {
+            let u = edges.from[i];
+            let v = edges.to[i];
+            let etype = edges.etype[i];
+
+            // Tail half at u (source), head half at v (target).
+            rows[u as usize].push(HalfEdge {
+                nbr: v,
+                etype,
+                side: Side::Tail,
+            });
+            rows[v as usize].push(HalfEdge {
+                nbr: u,
+                etype,
+                side: Side::Head,
+            });
+        }
+
+        // Sort each row for CSR canonical order.
+        for row in &mut rows {
+            row.sort_unstable();
+        }
+
+        // Build CSR arrays.
+        let mut row_index = Vec::with_capacity(n_us + 1);
+        row_index.push(0);
+        for row in &rows {
+            row_index.push(row_index.last().unwrap() + row.len() as u32);
+        }
+
+        let nnz = *row_index.last().unwrap() as usize;
+        let mut col = vec![0u32; nnz];
+        let mut ety = vec![0u8; nnz];
+        let mut side_arr = vec![0u8; nnz];
+
+        for (i, row) in rows.iter().enumerate() {
+            let mut k = row_index[i] as usize;
+            for h in row {
+                col[k] = h.nbr;
+                ety[k] = h.etype;
+                side_arr[k] = match h.side {
+                    Side::Tail => 0,
+                    Side::Head => 1,
+                };
+                k += 1;
+            }
+        }
+
+        let snap = RegistrySnapshot::from_specs(snapshot.specs.clone(), 1);
+        CaugiGraph::from_csr(row_index, col, ety, side_arr, simple, snap)
+    }
+
     pub fn finalize(mut self) -> Result<CaugiGraph, String> {
         self.take_and_build()
     }
@@ -177,7 +268,7 @@ impl GraphBuilder {
     fn build_from_rows(
         &mut self,
         mut rows: Vec<Vec<HalfEdge>>,
-        _seen: HashSet<(u32, u32, u8, bool)>,
+        _seen: FxHashSet<(u32, u32, u8, bool)>,
     ) -> Result<CaugiGraph, String> {
         let n = self.n as usize;
 

--- a/src/rust/src/graph/session.rs
+++ b/src/rust/src/graph/session.rs
@@ -17,6 +17,7 @@ use super::CaugiGraph;
 use super::RegistrySnapshot;
 use crate::edges::{EdgeRegistry, EdgeSpec};
 use crate::graph::NeighborMode;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -122,7 +123,7 @@ impl EdgeBuffer {
 /// The session holds:
 /// - **Variables**: Mutable inputs (n, simple, class, registry, edges, names)
 /// - **Declarations**: Lazily computed outputs (core, view)
-/// - **Queries**: Computed on demand without caching
+/// - **Queries**: Computed on demand (no query-level caching)
 ///
 /// # Invalidation Rules
 ///
@@ -140,13 +141,17 @@ pub struct GraphSession {
     edges: EdgeBuffer,
     names: Vec<String>,
     /// Maps node names to their 0-based indices for fast lookup.
-    name_to_index: HashMap<String, u32>,
+    /// Built lazily for sessions constructed from known index inputs.
+    name_to_index: RefCell<Option<HashMap<String, u32>>>,
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VALIDITY FLAGS
     // ═══════════════════════════════════════════════════════════════════════════
     core_valid: bool,
     view_valid: bool,
+    /// When true, edges are known to be valid (e.g., subset of an already-valid
+    /// graph) and `build_core` can skip per-edge validation.
+    edges_trusted: bool,
 
     // ═══════════════════════════════════════════════════════════════════════════
     // DECLARATIONS (computed values)
@@ -170,7 +175,7 @@ impl GraphSession {
         let snapshot = Arc::new(RegistrySnapshot::from_specs(specs, registry.len() as u32));
 
         let names: Vec<String> = (0..n).map(|i| format!("{}", i)).collect();
-        let name_to_index = Self::build_name_to_index(&names);
+        let name_to_index = Some(Self::build_name_to_index(&names));
 
         Self {
             n,
@@ -179,10 +184,11 @@ impl GraphSession {
             registry: snapshot,
             edges: EdgeBuffer::new(),
             names,
-            name_to_index,
+            name_to_index: RefCell::new(name_to_index),
 
             core_valid: false,
             view_valid: false,
+            edges_trusted: false,
 
             core: None,
             view: None,
@@ -197,7 +203,7 @@ impl GraphSession {
         class: GraphClass,
     ) -> Self {
         let names: Vec<String> = (0..n).map(|i| format!("{}", i)).collect();
-        let name_to_index = Self::build_name_to_index(&names);
+        let name_to_index = Some(Self::build_name_to_index(&names));
 
         Self {
             n,
@@ -206,12 +212,77 @@ impl GraphSession {
             registry,
             edges: EdgeBuffer::new(),
             names,
-            name_to_index,
+            name_to_index: RefCell::new(name_to_index),
 
             core_valid: false,
             view_valid: false,
+            edges_trusted: false,
 
             core: None,
+            view: None,
+        }
+    }
+
+    /// Create a new session from an existing registry snapshot plus full data.
+    /// Edges are marked as trusted (skipping validation on build).
+    pub fn from_snapshot_with_data(
+        registry: Arc<RegistrySnapshot>,
+        simple: bool,
+        class: GraphClass,
+        edges: EdgeBuffer,
+        names: Vec<String>,
+    ) -> Self {
+        let n = names.len() as u32;
+        Self {
+            n,
+            simple,
+            graph_class: class,
+            registry,
+            edges,
+            names,
+            name_to_index: RefCell::new(None),
+            core_valid: false,
+            view_valid: false,
+            edges_trusted: true,
+            core: None,
+            view: None,
+        }
+    }
+
+    /// Create a session with a pre-built CSR core (e.g., from CSR-based subgraph extraction).
+    /// The edge buffer is reconstructed from the CSR so future mutations are possible.
+    pub fn from_prebuilt_core(
+        registry: Arc<RegistrySnapshot>,
+        simple: bool,
+        class: GraphClass,
+        core: CaugiGraph,
+        names: Vec<String>,
+    ) -> Self {
+        // Reconstruct edge buffer from CSR: collect tail-side half-edges only
+        // (each undirected edge has both a tail and head half; we only want one copy).
+        let n = core.n();
+        let mut edges = EdgeBuffer::new();
+        for u in 0..n {
+            for k in core.row_range(u) {
+                if core.side[k] == 0 {
+                    // side 0 = Tail position → this node is the source
+                    edges.push(u, core.col_index[k], core.etype[k]);
+                }
+            }
+        }
+
+        Self {
+            n,
+            simple,
+            graph_class: class,
+            registry,
+            edges,
+            names,
+            name_to_index: RefCell::new(None),
+            core_valid: true,
+            view_valid: false,
+            edges_trusted: true,
+            core: Some(Arc::new(core)),
             view: None,
         }
     }
@@ -228,11 +299,12 @@ impl GraphSession {
             registry: Arc::clone(&self.registry),
             edges: self.edges.clone(),
             names: self.names.clone(),
-            name_to_index: self.name_to_index.clone(),
+            name_to_index: RefCell::new(self.name_to_index.borrow().as_ref().cloned()),
 
             // Invalidate all declarations in the clone
             core_valid: false,
             view_valid: false,
+            edges_trusted: self.edges_trusted,
             core: None,
             view: None,
         }
@@ -244,6 +316,7 @@ impl GraphSession {
 
     fn invalidate_core(&mut self) {
         self.core_valid = false;
+        self.edges_trusted = false;
         self.core = None;
         self.invalidate_view();
     }
@@ -336,7 +409,7 @@ impl GraphSession {
     }
 
     pub fn set_names(&mut self, names: Vec<String>) {
-        self.name_to_index = Self::build_name_to_index(&names);
+        *self.name_to_index.get_mut() = Some(Self::build_name_to_index(&names));
         self.names = names;
         // No invalidation - names are metadata
     }
@@ -361,7 +434,7 @@ impl GraphSession {
         self.graph_class = class;
         self.registry = registry;
         self.edges = edges;
-        self.name_to_index = Self::build_name_to_index(&names);
+        *self.name_to_index.get_mut() = Some(Self::build_name_to_index(&names));
         self.names = names;
         self.invalidate_core();
     }
@@ -371,8 +444,21 @@ impl GraphSession {
     // ═══════════════════════════════════════════════════════════════════════════
 
     fn build_core(&self) -> Result<CaugiGraph, String> {
-        let mut builder =
-            GraphBuilder::new_from_snapshot(self.n, self.simple, Arc::clone(&self.registry));
+        if self.edges_trusted {
+            return GraphBuilder::build_from_edge_buffer(
+                self.n,
+                self.simple,
+                &self.edges,
+                Arc::clone(&self.registry),
+            );
+        }
+
+        let mut builder = GraphBuilder::new_from_snapshot_with_capacity(
+            self.n,
+            self.simple,
+            Arc::clone(&self.registry),
+            self.edges.len(),
+        );
 
         for i in 0..self.edges.len() {
             builder
@@ -811,15 +897,32 @@ impl GraphSession {
     /// Look up the 0-based index of a node by name.
     /// Returns `None` if the name is not found.
     pub fn index_of(&self, name: &str) -> Option<u32> {
-        self.name_to_index.get(name).copied()
+        if let Some(map) = self.name_to_index.borrow().as_ref() {
+            return map.get(name).copied();
+        }
+
+        let built = Self::build_name_to_index(&self.names);
+        let out = built.get(name).copied();
+        *self.name_to_index.borrow_mut() = Some(built);
+        out
     }
 
     /// Look up the 0-based indices of multiple nodes by name.
     /// Returns an error if any name is not found.
     pub fn indices_of(&self, names: &[String]) -> Result<Vec<u32>, String> {
+        if self.name_to_index.borrow().is_none() {
+            let built = Self::build_name_to_index(&self.names);
+            *self.name_to_index.borrow_mut() = Some(built);
+        }
+
+        let map_ref = self.name_to_index.borrow();
+        let map = map_ref
+            .as_ref()
+            .expect("name_to_index must be initialized before lookup");
+
         let mut result = Vec::with_capacity(names.len());
         for name in names {
-            match self.name_to_index.get(name) {
+            match map.get(name) {
                 Some(&idx) => result.push(idx),
                 None => return Err(format!("Non-existent node name: {}", name)),
             }

--- a/src/rust/src/graph/session.rs
+++ b/src/rust/src/graph/session.rs
@@ -17,8 +17,8 @@ use super::CaugiGraph;
 use super::RegistrySnapshot;
 use crate::edges::{EdgeRegistry, EdgeSpec};
 use crate::graph::NeighborMode;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// The target graph class for typed view construction.
@@ -141,8 +141,7 @@ pub struct GraphSession {
     edges: EdgeBuffer,
     names: Vec<String>,
     /// Maps node names to their 0-based indices for fast lookup.
-    /// Built lazily for sessions constructed from known index inputs.
-    name_to_index: RefCell<Option<HashMap<String, u32>>>,
+    name_to_index: HashMap<String, u32>,
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VALIDITY FLAGS
@@ -175,7 +174,7 @@ impl GraphSession {
         let snapshot = Arc::new(RegistrySnapshot::from_specs(specs, registry.len() as u32));
 
         let names: Vec<String> = (0..n).map(|i| format!("{}", i)).collect();
-        let name_to_index = Some(Self::build_name_to_index(&names));
+        let name_to_index = Self::build_name_to_index(&names);
 
         Self {
             n,
@@ -184,7 +183,7 @@ impl GraphSession {
             registry: snapshot,
             edges: EdgeBuffer::new(),
             names,
-            name_to_index: RefCell::new(name_to_index),
+            name_to_index,
 
             core_valid: false,
             view_valid: false,
@@ -203,7 +202,7 @@ impl GraphSession {
         class: GraphClass,
     ) -> Self {
         let names: Vec<String> = (0..n).map(|i| format!("{}", i)).collect();
-        let name_to_index = Some(Self::build_name_to_index(&names));
+        let name_to_index = Self::build_name_to_index(&names);
 
         Self {
             n,
@@ -212,7 +211,7 @@ impl GraphSession {
             registry,
             edges: EdgeBuffer::new(),
             names,
-            name_to_index: RefCell::new(name_to_index),
+            name_to_index,
 
             core_valid: false,
             view_valid: false,
@@ -233,6 +232,7 @@ impl GraphSession {
         names: Vec<String>,
     ) -> Self {
         let n = names.len() as u32;
+        let name_to_index = Self::build_name_to_index(&names);
         Self {
             n,
             simple,
@@ -240,7 +240,7 @@ impl GraphSession {
             registry,
             edges,
             names,
-            name_to_index: RefCell::new(None),
+            name_to_index,
             core_valid: false,
             view_valid: false,
             edges_trusted: true,
@@ -271,6 +271,7 @@ impl GraphSession {
             }
         }
 
+        let name_to_index = Self::build_name_to_index(&names);
         Self {
             n,
             simple,
@@ -278,7 +279,7 @@ impl GraphSession {
             registry,
             edges,
             names,
-            name_to_index: RefCell::new(None),
+            name_to_index,
             core_valid: true,
             view_valid: false,
             edges_trusted: true,
@@ -299,7 +300,7 @@ impl GraphSession {
             registry: Arc::clone(&self.registry),
             edges: self.edges.clone(),
             names: self.names.clone(),
-            name_to_index: RefCell::new(self.name_to_index.borrow().as_ref().cloned()),
+            name_to_index: self.name_to_index.clone(),
 
             // Invalidate all declarations in the clone
             core_valid: false,
@@ -350,7 +351,7 @@ impl GraphSession {
     }
 
     pub fn replace_edges_for_pairs(&mut self, new_edges: EdgeBuffer) {
-        let mut remove_pairs: HashSet<(u32, u32)> = HashSet::with_capacity(new_edges.len());
+        let mut remove_pairs: FxHashSet<(u32, u32)> = FxHashSet::with_capacity_and_hasher(new_edges.len(), Default::default());
         if self.simple {
             for i in 0..new_edges.len() {
                 let u = new_edges.from[i];
@@ -365,8 +366,8 @@ impl GraphSession {
         }
 
         let mut kept = EdgeBuffer::with_capacity(self.edges.len() + new_edges.len());
-        let mut seen: HashSet<(u32, u32, u8)> =
-            HashSet::with_capacity(self.edges.len() + new_edges.len());
+        let mut seen: FxHashSet<(u32, u32, u8)> =
+            FxHashSet::with_capacity_and_hasher(self.edges.len() + new_edges.len(), Default::default());
 
         for i in 0..self.edges.len() {
             let u = self.edges.from[i];
@@ -409,7 +410,7 @@ impl GraphSession {
     }
 
     pub fn set_names(&mut self, names: Vec<String>) {
-        *self.name_to_index.get_mut() = Some(Self::build_name_to_index(&names));
+        self.name_to_index = Self::build_name_to_index(&names);
         self.names = names;
         // No invalidation - names are metadata
     }
@@ -434,7 +435,7 @@ impl GraphSession {
         self.graph_class = class;
         self.registry = registry;
         self.edges = edges;
-        *self.name_to_index.get_mut() = Some(Self::build_name_to_index(&names));
+        self.name_to_index = Self::build_name_to_index(&names);
         self.names = names;
         self.invalidate_core();
     }
@@ -897,32 +898,15 @@ impl GraphSession {
     /// Look up the 0-based index of a node by name.
     /// Returns `None` if the name is not found.
     pub fn index_of(&self, name: &str) -> Option<u32> {
-        if let Some(map) = self.name_to_index.borrow().as_ref() {
-            return map.get(name).copied();
-        }
-
-        let built = Self::build_name_to_index(&self.names);
-        let out = built.get(name).copied();
-        *self.name_to_index.borrow_mut() = Some(built);
-        out
+        self.name_to_index.get(name).copied()
     }
 
     /// Look up the 0-based indices of multiple nodes by name.
     /// Returns an error if any name is not found.
     pub fn indices_of(&self, names: &[String]) -> Result<Vec<u32>, String> {
-        if self.name_to_index.borrow().is_none() {
-            let built = Self::build_name_to_index(&self.names);
-            *self.name_to_index.borrow_mut() = Some(built);
-        }
-
-        let map_ref = self.name_to_index.borrow();
-        let map = map_ref
-            .as_ref()
-            .expect("name_to_index must be initialized before lookup");
-
         let mut result = Vec::with_capacity(names.len());
         for name in names {
-            match map.get(name) {
+            match self.name_to_index.get(name) {
                 Some(&idx) => result.push(idx),
                 None => return Err(format!("Non-existent node name: {}", name)),
             }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -83,9 +83,9 @@ fn session_ptr_from_cg(cg: &Robj) -> ExternalPtr<GraphSession> {
 }
 
 fn parse_parent_nodes(nodes: Robj) -> Vec<String> {
-    let node_strings: Strings = nodes.try_into().unwrap_or_else(|_| {
-        throw_r_error("`nodes` must be a character vector of node names.")
-    });
+    let node_strings: Strings = nodes
+        .try_into()
+        .unwrap_or_else(|_| throw_r_error("`nodes` must be a character vector of node names."));
 
     let mut out = Vec::with_capacity(node_strings.len());
     for i in 0..node_strings.len() {
@@ -130,7 +130,10 @@ fn parse_parent_index0(index: Robj) -> Vec<i32> {
     throw_r_error("`index` must be numeric.");
 }
 
-fn parse_subgraph_index1(index: Robj) -> Vec<i32> {
+fn parse_subgraph_keep_index(index: Robj, n: u32) -> Vec<u32> {
+    let mut seen = vec![false; n as usize];
+    let n_i32 = n as i32;
+
     if index.is_integer() {
         let idx_int: Integers = index
             .try_into()
@@ -140,7 +143,16 @@ fn parse_subgraph_index1(index: Robj) -> Vec<i32> {
             if x.is_na() {
                 throw_r_error("`index` cannot contain NA values.");
             }
-            out.push(x.inner());
+            let i = x.inner();
+            if i < 1 || i > n_i32 {
+                throw_r_error("`index` out of range (1..n).");
+            }
+            let ui = (i - 1) as usize;
+            if seen[ui] {
+                throw_r_error("`nodes`/`index` contains duplicates.");
+            }
+            seen[ui] = true;
+            out.push(ui as u32);
         }
         return out;
     }
@@ -154,7 +166,16 @@ fn parse_subgraph_index1(index: Robj) -> Vec<i32> {
             if x.is_na() {
                 throw_r_error("`index` cannot contain NA values.");
             }
-            out.push(x.inner().trunc() as i32);
+            let i = x.inner().trunc() as i32;
+            if i < 1 || i > n_i32 {
+                throw_r_error("`index` out of range (1..n).");
+            }
+            let ui = (i - 1) as usize;
+            if seen[ui] {
+                throw_r_error("`nodes`/`index` contains duplicates.");
+            }
+            seen[ui] = true;
+            out.push(ui as u32);
         }
         return out;
     }
@@ -235,7 +256,9 @@ fn parse_neighbors_mode(mode: Robj) -> String {
     match matches.len() {
         1 => matches[0].to_string(),
         0 => throw_r_error("`mode` must be one of: all, in, out, undirected, bidirected, partial."),
-        _ => throw_r_error("`mode` is ambiguous. Use one of: all, in, out, undirected, bidirected, partial."),
+        _ => throw_r_error(
+            "`mode` is ambiguous. Use one of: all, in, out, undirected, bidirected, partial.",
+        ),
     }
 }
 
@@ -1156,44 +1179,47 @@ fn rs_build(mut session: ExternalPtr<GraphSession>) {
 }
 
 #[extendr]
-fn parents(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-) -> Robj {
+fn parents(cg: Robj, nodes: Robj, index: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     run_relation_query(&mut session, idx0, "idx", "idxs", |s, i| {
         s.as_mut().parents_of(i).map_err(|e| e)
     })
 }
 
 #[extendr]
-fn children(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-) -> Robj {
+fn children(cg: Robj, nodes: Robj, index: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     run_relation_query(&mut session, idx0, "idx", "idxs", |s, i| {
         s.as_mut().children_of(i).map_err(|e| e)
     })
 }
 
 #[extendr]
-fn neighbors(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-    mode: Robj,
-) -> Robj {
+fn neighbors(cg: Robj, nodes: Robj, index: Robj, mode: Robj) -> Robj {
     use graph::NeighborMode;
 
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     let mode_norm = parse_neighbors_mode(mode);
-    let neighbor_mode = NeighborMode::from_str(mode_norm.as_str()).unwrap_or_else(|e| throw_r_error(e));
+    let neighbor_mode =
+        NeighborMode::from_str(mode_norm.as_str()).unwrap_or_else(|e| throw_r_error(e));
 
     run_relation_query(&mut session, idx0, "idx", "idxs", move |s, i| {
         s.as_mut().neighbors_of(i, neighbor_mode).map_err(|e| e)
@@ -1201,14 +1227,14 @@ fn neighbors(
 }
 
 #[extendr]
-fn ancestors(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-    open: Robj,
-) -> Robj {
+fn ancestors(cg: Robj, nodes: Robj, index: Robj, open: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     let open_flag = parse_open_arg(open);
 
     run_relation_query(&mut session, idx0, "node", "node", move |s, i| {
@@ -1221,14 +1247,14 @@ fn ancestors(
 }
 
 #[extendr]
-fn descendants(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-    open: Robj,
-) -> Robj {
+fn descendants(cg: Robj, nodes: Robj, index: Robj, open: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     let open_flag = parse_open_arg(open);
 
     run_relation_query(&mut session, idx0, "node", "node", move |s, i| {
@@ -1241,14 +1267,14 @@ fn descendants(
 }
 
 #[extendr]
-fn anteriors(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-    open: Robj,
-) -> Robj {
+fn anteriors(cg: Robj, nodes: Robj, index: Robj, open: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     let open_flag = parse_open_arg(open);
 
     run_relation_query(&mut session, idx0, "node", "node", move |s, i| {
@@ -1261,12 +1287,7 @@ fn anteriors(
 }
 
 #[extendr]
-fn posteriors(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-    open: Robj,
-) -> Robj {
+fn posteriors(cg: Robj, nodes: Robj, index: Robj, open: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
     let idx0 = resolve_query_idx0(&session, nodes, index, "Supply one of `nodes` or `index`.");
     let open_flag = parse_open_arg(open);
@@ -1281,38 +1302,35 @@ fn posteriors(
 }
 
 #[extendr]
-fn markov_blanket(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-) -> Robj {
+fn markov_blanket(cg: Robj, nodes: Robj, index: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     run_relation_query(&mut session, idx0, "node", "node", |s, i| {
         s.as_mut().markov_blanket_of(i).map_err(|e| e)
     })
 }
 
 #[extendr]
-fn spouses(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-) -> Robj {
+fn spouses(cg: Robj, nodes: Robj, index: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
-    let idx0 = resolve_query_idx0(&session, nodes, index, "Must supply either `nodes` or `index`.");
+    let idx0 = resolve_query_idx0(
+        &session,
+        nodes,
+        index,
+        "Must supply either `nodes` or `index`.",
+    );
     run_relation_query(&mut session, idx0, "idx", "idxs", |s, i| {
         s.as_mut().spouses_of(i).map_err(|e| e)
     })
 }
 
 #[extendr]
-fn districts(
-    cg: Robj,
-    nodes: Robj,
-    index: Robj,
-    all: Robj,
-) -> Robj {
+fn districts(cg: Robj, nodes: Robj, index: Robj, all: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
 
     let nodes_supplied = !nodes.is_null();
@@ -1442,10 +1460,7 @@ fn topological_sort(cg: Robj) -> Robj {
 }
 
 #[extendr]
-fn exogenous(
-    cg: Robj,
-    undirected_as_parents: Robj,
-) -> Robj {
+fn exogenous(cg: Robj, undirected_as_parents: Robj) -> Robj {
     let mut session = session_ptr_from_cg(&cg);
     let undirected = parse_single_logical(
         undirected_as_parents,
@@ -1612,58 +1627,73 @@ fn induced_subgraph_session_from_keep(
     session: &mut ExternalPtr<GraphSession>,
     keep_u: &[u32],
 ) -> ExternalPtr<GraphSession> {
-    for &i in keep_u {
-        if i >= session.as_ref().n() {
-            throw_r_error(format!("Index {} is out of bounds", i));
+    let s = session.as_mut();
+    let n_old = s.n() as usize;
+
+    // Collect names for kept nodes.
+    let mut names: Vec<String> = Vec::with_capacity(keep_u.len());
+    for &old_i in keep_u {
+        if (old_i as usize) >= n_old {
+            throw_r_error(format!("Index {} is out of bounds", old_i));
         }
+        names.push(s.names()[old_i as usize].clone());
     }
 
-    let view = session.as_mut().view().unwrap_or_else(|e| throw_r_error(e));
-    let sub_view = view
-        .as_ref()
-        .induced_subgraph(keep_u)
-        .unwrap_or_else(|e| throw_r_error(e));
+    // Fast path: if CSR core is already built, use CSR-induced subgraph.
+    // This only touches the adjacency of kept nodes instead of scanning all edges.
+    if s.is_core_valid() {
+        let core = s.core().unwrap_or_else(|e| throw_r_error(e));
+        let (sub_core, _new_to_old, _old_to_new) = core
+            .induced_subgraph(keep_u)
+            .unwrap_or_else(|e| throw_r_error(e));
 
-    let names: Vec<String> = keep_u
-        .iter()
-        .map(|&i| session.as_ref().names()[i as usize].clone())
-        .collect();
+        let out = GraphSession::from_prebuilt_core(
+            Arc::clone(s.registry()),
+            s.simple(),
+            s.class(),
+            sub_core,
+            names,
+        );
+        return ExternalPtr::new(out);
+    }
 
-    // Preserve original input edge orientation/order by filtering the source
-    // session EdgeBuffer, then remap old node ids to induced-subgraph ids.
-    let n_old = session.as_ref().n() as usize;
+    // Slow path: scan edge buffer when CSR is not yet built.
     let mut old_to_new = vec![u32::MAX; n_old];
     for (new_i, &old_i) in keep_u.iter().enumerate() {
+        if old_to_new[old_i as usize] != u32::MAX {
+            throw_r_error("duplicate node id in `keep`");
+        }
         old_to_new[old_i as usize] = new_i as u32;
     }
 
-    let src_edges = session.as_ref().edge_buffer();
-    let mut kept_edges = EdgeBuffer::with_capacity(src_edges.len());
-    for i in 0..src_edges.len() {
-        let old_from = src_edges.from[i] as usize;
-        let old_to = src_edges.to[i] as usize;
+    // Single pass with heuristic capacity estimate.
+    let eb = s.edge_buffer();
+    let edge_len = eb.len();
+    let keep_frac = keep_u.len() as f64 / n_old.max(1) as f64;
+    let est = (keep_frac * keep_frac * edge_len as f64) as usize;
+    let mut kept_edges = EdgeBuffer::with_capacity(est);
+    for i in 0..edge_len {
+        let old_from = eb.from[i] as usize;
+        let old_to = eb.to[i] as usize;
         if old_from >= n_old || old_to >= n_old {
             continue;
         }
-
         let new_from = old_to_new[old_from];
         let new_to = old_to_new[old_to];
         if new_from != u32::MAX && new_to != u32::MAX {
-            kept_edges.push(new_from, new_to, src_edges.etype[i]);
+            kept_edges.push(new_from, new_to, eb.etype[i]);
         }
     }
 
-    // Build output session directly to avoid materializing edge buffer from the
-    // temporary subgraph core (we already have the desired filtered edge order).
-    let sub_core = sub_view.core();
-    let mut out = GraphSession::from_snapshot(
-        Arc::new(sub_core.registry.clone()),
-        sub_core.n(),
-        sub_core.simple,
-        graph_class_from_view(&sub_view),
+    // Edges are trusted (subset of a valid graph) so build_core will use
+    // the fast bulk path when the CSR is eventually needed.
+    let out = GraphSession::from_snapshot_with_data(
+        Arc::clone(s.registry()),
+        s.simple(),
+        s.class(),
+        kept_edges,
+        names,
     );
-    out.set_names(names);
-    out.set_edges(kept_edges);
     ExternalPtr::new(out)
 }
 
@@ -1693,49 +1723,64 @@ fn subgraph(cg: Robj, nodes: Robj, index: Robj) -> Robj {
     }
 
     let keep_u: Vec<u32> = if index_supplied {
-        let idx1 = parse_subgraph_index1(index);
-        let n = session.as_ref().n() as i32;
-        if idx1.iter().any(|&i| i < 1 || i > n) {
-            throw_r_error("`index` out of range (1..n).");
-        }
-        idx1.into_iter().map(|i| (i - 1) as u32).collect()
+        parse_subgraph_keep_index(index, session.as_ref().n())
     } else {
-        let node_strings: Strings = nodes.try_into().unwrap_or_else(|_| {
-            throw_r_error("`nodes` must be a character vector of node names.")
-        });
+        let node_strings: Strings = nodes
+            .try_into()
+            .unwrap_or_else(|_| throw_r_error("`nodes` must be a character vector of node names."));
+        let sref = session.as_ref();
+        let n = sref.n();
 
         let mut keep = Vec::with_capacity(node_strings.len());
-        let mut miss_seen: HashSet<String> = HashSet::new();
-        let mut miss: Vec<String> = Vec::new();
+        let mut seen = vec![false; n as usize];
+        let mut has_duplicate = false;
+        let mut first_missing: Option<String> = None;
 
-        for i in 0..node_strings.len() {
-            let s = node_strings.elt(i);
+        for s in node_strings.iter() {
             if s.is_na() {
                 throw_r_error("`nodes` cannot contain NA values.");
             }
             let name = s.as_str();
-            match session.as_ref().index_of(name) {
-                Some(idx) => keep.push(idx),
-                None => {
-                    if miss_seen.insert(name.to_string()) {
-                        miss.push(name.to_string());
+            let idx = sref.index_of(name);
+            match idx {
+                Some(idx) => {
+                    let ui = idx as usize;
+                    if seen[ui] {
+                        has_duplicate = true;
+                    } else {
+                        seen[ui] = true;
                     }
+                    keep.push(idx);
+                }
+                None => {
+                    first_missing = Some(name.to_string());
+                    break;
                 }
             }
         }
 
-        if !miss.is_empty() {
+        if let Some(first) = first_missing {
+            let mut miss_seen: HashSet<String> = HashSet::new();
+            let mut miss: Vec<String> = Vec::new();
+            miss_seen.insert(first.clone());
+            miss.push(first);
+            for s in node_strings.iter() {
+                if s.is_na() {
+                    continue;
+                }
+                let name = s.as_str();
+                let missing = sref.index_of(name).is_none();
+                if missing && miss_seen.insert(name.to_string()) {
+                    miss.push(name.to_string());
+                }
+            }
             throw_r_error(format!("Unknown node(s): {}", miss.join(", ")));
+        }
+        if has_duplicate {
+            throw_r_error("`nodes`/`index` contains duplicates.");
         }
         keep
     };
-
-    let mut seen: HashSet<u32> = HashSet::with_capacity(keep_u.len());
-    for &idx in &keep_u {
-        if !seen.insert(idx) {
-            throw_r_error("`nodes`/`index` contains duplicates.");
-        }
-    }
 
     let sub_session = induced_subgraph_session_from_keep(&mut session, &keep_u);
     caugi_from_session_ptr(&cg, sub_session)

--- a/vignettes/articles/performance.Rmd
+++ b/vignettes/articles/performance.Rmd
@@ -79,6 +79,9 @@ ggmg <- graphs$ggmg
 bng <- graphs$bng
 dg <- graphs$dg
 
+# build the caugi to reflect correct runtime
+cg <- caugi::build(cg)
+
 test_node_index <- sample(1000, 1)
 test_node_name <- paste0("V", test_node_index)
 
@@ -249,8 +252,9 @@ We see that `caugi` again outperforms the other packages by a large margin.
 
 #### Subgraph (building)
 
-Here we see an example of where the frontloading hurts performance. When we build a subgraph, we have to rebuild the entire `caugi` graph object. Here, we see that while `caugi` outperforms other packages for queries, it is slower for building the graph
-object itself compared to `igraph`, as seen below:
+Subgraph extraction is where we explicitly test graph _building_ performance.
+When extracting a subgraph, `caugi` must construct a new graph object with its CSR indexes, so this benchmark captures the cost of that frontloaded work.
+Note that `caugi::subgraph()` is called on a graph that has already been built.
 
 ```{r benchmark-subgraph}
 #| fig-cap: "Benchmarking subgraph extraction for different packages."
@@ -259,7 +263,8 @@ subgraph_nodes <- paste0("V", subgraph_nodes_index)
 
 bm_subgraph <- bench::mark(
   caugi = {
-    caugi::subgraph(cg, subgraph_nodes)
+    sg <- caugi::subgraph(cg, subgraph_nodes)
+    caugi::build(sg)
   },
   igraph = {
     igraph::subgraph(ig, subgraph_nodes)
@@ -273,6 +278,60 @@ bm_subgraph <- bench::mark(
 plot(bm_subgraph)
 ```
 
+To make the comparison more demanding, we also benchmark two larger settings where we only compare `caugi` and `igraph` directly.
+This isolates subgraph building performance at scale without the conversion overhead of other packages.
+
+```{r benchmark-subgraph-large-sparse}
+#| fig-cap: "Subgraph extraction on a large sparse graph (n = 10000, p = 0.05)."
+n_large <- 10000
+sub_frac <- 0.10
+sub_k <- as.integer(n_large * sub_frac)
+
+cg_large_sparse <- caugi::generate_graph(n = n_large, p = 0.05, class = "DAG")
+caugi::build(cg_large_sparse)
+ig_large_sparse <- caugi::as_igraph(cg_large_sparse)
+sub_idx_sparse <- sample.int(n_large, sub_k)
+sub_nodes_sparse <- paste0("V", sub_idx_sparse)
+
+bm_subgraph_large_sparse <- bench::mark(
+  caugi = {
+    sg <- caugi::subgraph(cg_large_sparse, sub_nodes_sparse)
+    caugi::build(sg)
+  },
+  igraph = {
+    igraph::subgraph(ig_large_sparse, sub_nodes_sparse)
+  },
+  check = FALSE,
+  iterations = 30
+)
+
+plot(bm_subgraph_large_sparse)
+```
+
+```{r benchmark-subgraph-large-dense}
+#| fig-cap: "Subgraph extraction on a large dense graph (n = 10000, p = 0.25)."
+cg_large_dense <- caugi::generate_graph(n = n_large, p = 0.25, class = "DAG")
+caugi::build(cg_large_dense)
+ig_large_dense <- caugi::as_igraph(cg_large_dense)
+sub_idx_dense <- sample.int(n_large, sub_k)
+sub_nodes_dense <- paste0("V", sub_idx_dense)
+
+bm_subgraph_large_dense <- bench::mark(
+  caugi = {
+    sg <- caugi::subgraph(cg_large_dense, sub_nodes_dense)
+    caugi::build(sg)
+  },
+  igraph = {
+    igraph::subgraph(ig_large_dense, sub_nodes_dense)
+  },
+  check = FALSE,
+  iterations = 20
+)
+
+plot(bm_subgraph_large_dense)
+```
+
+We see that `caugi` is competitive with `igraph` for subgraph extraction, even though `caugi` must rebuild its full CSR representation for the result, even though `igraph` has a slight edge.
 
 ### Session info
 

--- a/vignettes/articles/performance.Rmd
+++ b/vignettes/articles/performance.Rmd
@@ -331,8 +331,7 @@ bm_subgraph_large_dense <- bench::mark(
 plot(bm_subgraph_large_dense)
 ```
 
-We see that `caugi` is competitive with `igraph` for subgraph extraction, even though `caugi` must rebuild its full CSR representation for the result, even though `igraph` has a slight edge.
-
+We see that `caugi` is competitive with `igraph` for subgraph extraction, even though `caugi` must rebuild its full CSR representation for the result. `igraph` does still have a slight edge. 
 ### Session info
 
 ```{r session-info}

--- a/vignettes/articles/performance.Rmd
+++ b/vignettes/articles/performance.Rmd
@@ -309,7 +309,7 @@ plot(bm_subgraph_large_sparse)
 ```
 
 ```{r benchmark-subgraph-large-dense}
-#| fig-cap: "Subgraph extraction on a large dense graph (n = 10000, p = 0.25)."
+#| fig-cap: "Subgraph extraction on a large dense graph (`n = 10000`, `p = 0.25`)."
 cg_large_dense <- caugi::generate_graph(n = n_large, p = 0.25, class = "DAG")
 caugi::build(cg_large_dense)
 ig_large_dense <- caugi::as_igraph(cg_large_dense)


### PR DESCRIPTION
## Summary 

Increase performance of the subgraph run and builder to make the gap between `igraph` and `caugi` smaller. 

<p><strong><code>builder.rs</code></strong></p>
<ul>
<li><code>HashSet</code> → <code>FxHashSet</code> (faster non-crypto hash) for dedup sets</li>
<li>New <code>new_from_snapshot_with_capacity</code> constructor — pre-reserves hash set capacity based on expected edge count</li>
<li>New <code>build_from_edge_buffer</code> fast path — bypasses per-edge validation and hash-set dedup entirely when edges are known trusted, goes straight to CSR construction</li>
</ul>
<p><strong><code>session.rs</code></strong></p>
<ul>
<li>New <code>edges_trusted</code> flag — set when edges come from a validated source (subgraph of a valid graph)</li>
<li>New <code>from_snapshot_with_data</code> constructor — creates a session from pre-validated edges, marks them trusted</li>
<li>New <code>from_prebuilt_core</code> constructor — creates a session from an already-built CSR graph (e.g. from CSR-based subgraph), reconstructs edge buffer from tail half-edges</li>
<li><code>build_core</code> dispatches to the fast <code>build_from_edge_buffer</code> path when <code>edges_trusted</code>; otherwise uses the capacity-hinted builder</li>
</ul>
<p><strong><code>lib.rs</code></strong></p>
<ul>
<li><code>parse_subgraph_keep_index</code> — replaces <code>parse_subgraph_index1</code>, does bounds + duplicate checking inline with a <code>seen</code> bitvector (no hash set)</li>
<li><code>induced_subgraph_session_from_keep</code> — <strong>fast path</strong>: if CSR is already built, uses CSR-level <code>induced_subgraph</code> (only touches adjacency of kept nodes) + <code>from_prebuilt_core</code>; <strong>slow path</strong>: scans edge buffer with heuristic capacity estimate for the filtered edge list, uses <code>from_snapshot_with_data</code></li>
</ul>
<hr>
<h2>Benchmark results</h2>

Benchmark | main median | PR median | Speedup
-- | -- | -- | --
subgraph+build (n=1000, sub=100) | 322 µs | 71.7 µs | 4.5×
build only (n=1000, p=0.3) | 26.4 ms | 18.4 ms | 1.4×
subgraph+build sparse (n=10k, sub=1k) | 6.65 ms | 1.87 ms | 3.6×
subgraph+build dense (n=10k, sub=1k) | 35.2 ms | 8.46 ms | 4.2×


<p>The subgraph speedup (3.6–4.5×) comes mainly from the CSR fast path in <code>induced_subgraph_session_from_keep</code>. The build speedup (~1.4×) comes from <code>FxHashSet</code>, pre-reserved capacity, and the trusted-edge bypass.</p></body></html>
