### PR TITLE
chore: setup devenv environment for development

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -32,3 +32,9 @@
 ^extras$
 ^paper$
 ^\.task$
+^\.direnv$
+^\.devenv$
+^\.envrc$
+^\devenv.lock$
+^\devenv.nix$
+^\devenv.yaml$

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+use devenv
+use vim

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,14 @@ target
 # latexindent
 indent.log
 .task/
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ To contribute to `caugi`, you'll need:
 2. **Rust toolchain** - See the DESCRIPTION file for minimum version requirements and system dependencies
 3. **Development tools** - Install the package using `pak::pak("frederikfabriciusbjerre/caugi")` which will handle all dependencies
 
+Alternatively, you can also use the [devenv](https://devenv.sh) configuration
+provided in the repository for a consistent development environment.
+
 ### Installing Rust
 
 If you don't have Rust installed, visit [rustup.rs](https://rustup.rs/) for installation instructions appropriate for your platform.

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,125 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1775507677,
+        "narHash": "sha256-gCv9ODisrHjTDtjV/Xru8dtDbrldahRZFShu089/60M=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "c429c111e25b467c431f9eb70598c70394d56aaa",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775036584,
+        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1774287239,
+        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,84 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  packages = [
+    pkgs.air-formatter
+    pkgs.bashInteractive
+    pkgs.cargo-audit
+    pkgs.cargo-deny
+    pkgs.cargo-flamegraph
+    pkgs.cargo-llvm-cov
+    pkgs.go-task
+    pkgs.jarl
+    pkgs.llvmPackages.bintools
+  ];
+
+  languages = {
+    rust = {
+      enable = true;
+    };
+
+    r = {
+      enable = true;
+
+      package = (
+        pkgs.rWrapper.override {
+          packages = with pkgs.rPackages; [
+            bench
+            bnlearn
+            dagitty
+            data_table
+            devtools
+            dplyr
+            fastmap
+            ggbeeswarm
+            ggm
+            graph
+            gRbase
+            gridExtra
+            igraph
+            jsonlite
+            knitr
+            MASS
+            Matrix
+            pcalg
+            processx
+            rextendr
+            rhub
+            rlang
+            rmarkdown
+            S7
+            spelling
+            testthat
+            tidyverse
+            urlchecker
+            usethis
+            waldo
+            withr
+          ];
+        }
+      );
+
+      lsp.enable = true;
+    };
+  };
+
+  git-hooks = {
+    hooks = {
+      clippy = {
+        enable = true;
+
+        settings = {
+          allFeatures = true;
+        };
+      };
+
+      rustfmt = {
+        enable = true;
+      };
+    };
+  };
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
This PR adds a development environment using devenv for nix users (like me). It means that someone can set up a development environment for caugi, with all the dependencies for R and Rust by just entering the directory and accepting a direnv prompt.

I also added a couple of pre-commit hooks for clippy and rustfmt (available through devenv only, so no effect for anyone else).