### PR TITLE
feat: add `MPDAG` class

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -38,3 +38,4 @@
 ^devenv\.lock$
 ^devenv\.nix$
 ^devenv\.yaml$
+^\.pre-commit-config\.yaml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -35,6 +35,6 @@
 ^\.direnv$
 ^\.devenv$
 ^\.envrc$
-^\devenv.lock$
-^\devenv.nix$
-^\devenv.yaml$
+^devenv\.lock$
+^devenv\.nix$
+^devenv\.yaml$

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ## New Features
 
 - Add `list_caugi_edges()` function to list all available edge types.
+- Add first-class `"MPDAG"` graph class support across constructor, class
+  mutation, and class resolution. `class = "AUTO"` now resolves Meek-closed
+  PDAGs to `"MPDAG"`.
 
 ## Improvements
 

--- a/R/as_caugi.R
+++ b/R/as_caugi.R
@@ -14,7 +14,7 @@
 #' - 3: tail (e.g., `A o-- B` or `A --- B`)
 #'
 #' @param x An object to convert to a `caugi`.
-#' @param class "DAG", "PDAG", "ADMG", "PAG", or "UNKNOWN".
+#' @param class "DAG", "PDAG", "MPDAG", "ADMG", "PAG", or "UNKNOWN".
 #' "PAG" is only supported for integer coded matrices.
 #' "ADMG" is for Acyclic Directed Mixed Graphs (with `-->` and `<->` edges).
 #' @param simple logical. If `TRUE` (default) the graph will be simple
@@ -98,7 +98,7 @@ as_caugi <- S7::new_generic(
   dispatch_args = "x",
   fun = function(
     x,
-    class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+    class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
     simple = TRUE,
     collapse = FALSE,
     collapse_to = "---",
@@ -113,7 +113,7 @@ S7::method(
   S7::new_S3_class("igraph")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -198,7 +198,7 @@ register_graphnel_s4_class <- function() {
     methods::getClassDef("graphNEL", package = "graph")
   ) <- function(
     x,
-    class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+    class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
     simple = TRUE,
     collapse = FALSE,
     collapse_to = "---",
@@ -274,7 +274,7 @@ S7::method(
   S7::new_S3_class("integer")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -464,7 +464,7 @@ S7::method(
   S7::new_S3_class("double")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -497,7 +497,7 @@ S7::method(
   S7::new_S3_class("logical")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -527,7 +527,7 @@ register_matrix_s4_class <- function() {
     methods::getClassDef("Matrix", package = "Matrix")
   ) <- function(
     x,
-    class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+    class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
     simple = TRUE,
     collapse = FALSE,
     collapse_to = "---",
@@ -551,7 +551,7 @@ S7::method(
   S7::new_S3_class("tidygraph")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -576,7 +576,7 @@ S7::method(
   S7::new_S3_class("dagitty")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -684,7 +684,7 @@ S7::method(
   S7::new_S3_class("bn")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",

--- a/R/caugi.R
+++ b/R/caugi.R
@@ -38,10 +38,10 @@
 #' @param simple Logical; if `TRUE` (default), the graph is a simple graph, and
 #' the function will throw an error if the input contains parallel edges or
 #' self-loops.
-#' @param class Character; one of `"AUTO"`, `"DAG"`, `"UG"`, `"PDAG"`, `"ADMG"`,
-#' `"AG"`, or `"UNKNOWN"`. `"AUTO"` will automatically pick the appropriate
-#' class based on the first match in the order of `"DAG"`, `"UG"`, `"PDAG"`,
-#' `"ADMG"`, and `"AG"`.
+#' @param class Character; one of `"AUTO"`, `"DAG"`, `"UG"`, `"PDAG"`, `"MPDAG"`,
+#' `"ADMG"`, `"AG"`, or `"UNKNOWN"`. `"AUTO"` will automatically pick the
+#' appropriate class based on the first match in the order of `"DAG"`, `"UG"`,
+#' `"MPDAG"`, `"PDAG"`, `"ADMG"`, and `"AG"`.
 #' It will default to `"UNKNOWN"` if no match is found.
 #' @param .session For internal use. Build a graph by supplying a
 #' pre-constructed session pointer from Rust.
@@ -244,7 +244,7 @@ caugi <- S7::new_class(
     edges_df = NULL,
     simple = TRUE,
     build = NULL, # deprecated
-    class = c("AUTO", "DAG", "UG", "PDAG", "ADMG", "AG", "UNKNOWN"),
+    class = c("AUTO", "DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "UNKNOWN"),
     state = NULL, # deprecated
     .session = NULL
   ) {

--- a/R/caugi_to.R
+++ b/R/caugi_to.R
@@ -19,7 +19,10 @@
 as_igraph <- function(x, ...) {
   is_caugi(x, throw_error = TRUE)
 
-  if (!(x@graph_class %in% c("DAG", "PDAG", "ADMG", "UG", "AG", "UNKNOWN"))) {
+  if (
+    !(x@graph_class %in%
+      c("DAG", "PDAG", "MPDAG", "ADMG", "UG", "AG", "UNKNOWN"))
+  ) {
     stop(
       "caugi graphs of class '",
       x@graph_class,

--- a/R/operations.R
+++ b/R/operations.R
@@ -234,6 +234,7 @@ mutate_caugi <- function(cg, class) {
     class,
     "DAG" = is_dag(cg),
     "PDAG" = is_pdag(cg),
+    "MPDAG" = is_mpdag(cg),
     "UG" = is_ug(cg),
     "ADMG" = is_admg(cg),
     "AG" = is_ag(cg),
@@ -801,8 +802,8 @@ are_connected <- function(cg, u, v) {
 #'
 #' @export
 dag_from_pdag <- function(PDAG) {
-  if (PDAG@graph_class != "PDAG") {
-    stop("Input must be a caugi PDAG graph")
+  if (!(PDAG@graph_class %in% c("PDAG", "MPDAG"))) {
+    stop("Input must be a caugi PDAG/MPDAG graph")
   }
 
   output_graph <- PDAG

--- a/R/queries.R
+++ b/R/queries.R
@@ -127,7 +127,8 @@ same_nodes <- function(cg1, cg2, throw_error = FALSE) {
 #' it, if possible.
 #'
 #' @details
-#' Logically, it should not be possible to have a graph class of "DAG" or "PDAG"
+#' Logically, it should not be possible to have a graph class of "DAG", "PDAG",
+#' or "MPDAG"
 #' that has cycles, but in case the user modified the graph after creation in
 #' some unforeseen way that could have introduced cycles, this function allows
 #' to force a check of acyclicity, if needed.
@@ -160,7 +161,8 @@ is_acyclic <- function(cg, force_check = FALSE) {
     is_it <- rs_is_acyclic(cg@session)
   } else if (
     identical(cg@graph_class, "DAG") ||
-      identical(cg@graph_class, "PDAG")
+      identical(cg@graph_class, "PDAG") ||
+      identical(cg@graph_class, "MPDAG")
   ) {
     is_it <- TRUE
   } else {
@@ -315,7 +317,7 @@ is_dag <- function(cg, force_check = FALSE) {
 is_pdag <- function(cg, force_check = FALSE) {
   is_caugi(cg, throw_error = TRUE)
 
-  if (identical(cg@graph_class, "PDAG") && !force_check) {
+  if (cg@graph_class %in% c("PDAG", "MPDAG") && !force_check) {
     is_it <- TRUE
   } else {
     # if we can't be sure from the class, we check

--- a/devenv.nix
+++ b/devenv.nix
@@ -65,20 +65,4 @@
       lsp.enable = true;
     };
   };
-
-  git-hooks = {
-    hooks = {
-      clippy = {
-        enable = true;
-
-        settings = {
-          allFeatures = true;
-        };
-      };
-
-      rustfmt = {
-        enable = true;
-      };
-    };
-  };
 }

--- a/man/as_caugi.Rd
+++ b/man/as_caugi.Rd
@@ -6,7 +6,7 @@
 \usage{
 as_caugi(
   x,
-  class = c("DAG", "PDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -16,7 +16,7 @@ as_caugi(
 \arguments{
 \item{x}{An object to convert to a \code{caugi}.}
 
-\item{class}{"DAG", "PDAG", "ADMG", "PAG", or "UNKNOWN".
+\item{class}{"DAG", "PDAG", "MPDAG", "ADMG", "PAG", or "UNKNOWN".
 "PAG" is only supported for integer coded matrices.
 "ADMG" is for Acyclic Directed Mixed Graphs (with \verb{-->} and \verb{<->} edges).}
 

--- a/man/caugi.Rd
+++ b/man/caugi.Rd
@@ -13,7 +13,7 @@ caugi(
   edges_df = NULL,
   simple = TRUE,
   build = NULL,
-  class = c("AUTO", "DAG", "UG", "PDAG", "ADMG", "AG", "UNKNOWN"),
+  class = c("AUTO", "DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "UNKNOWN"),
   state = NULL,
   .session = NULL
 )
@@ -50,10 +50,10 @@ self-loops.}
 \item{build}{DEPRECATED. The graph is always built lazily, so this argument is ignored.
 Can use \code{\link[=build]{build()}} to force lazy compilation if desired.}
 
-\item{class}{Character; one of \code{"AUTO"}, \code{"DAG"}, \code{"UG"}, \code{"PDAG"}, \code{"ADMG"},
-\code{"AG"}, or \code{"UNKNOWN"}. \code{"AUTO"} will automatically pick the appropriate
-class based on the first match in the order of \code{"DAG"}, \code{"UG"}, \code{"PDAG"},
-\code{"ADMG"}, and \code{"AG"}.
+\item{class}{Character; one of \code{"AUTO"}, \code{"DAG"}, \code{"UG"}, \code{"PDAG"}, \code{"MPDAG"},
+\code{"ADMG"}, \code{"AG"}, or \code{"UNKNOWN"}. \code{"AUTO"} will automatically pick the
+appropriate class based on the first match in the order of \code{"DAG"}, \code{"UG"},
+\code{"MPDAG"}, \code{"PDAG"}, \code{"ADMG"}, and \code{"AG"}.
 It will default to \code{"UNKNOWN"} if no match is found.}
 
 \item{state}{DEPRECATED. Replaced by \code{.session}.}

--- a/man/is_acyclic.Rd
+++ b/man/is_acyclic.Rd
@@ -20,7 +20,8 @@ A logical value indicating whether the graph is acyclic.
 Checks if the given \code{caugi} graph is acyclic.
 }
 \details{
-Logically, it should not be possible to have a graph class of "DAG" or "PDAG"
+Logically, it should not be possible to have a graph class of "DAG", "PDAG",
+or "MPDAG"
 that has cycles, but in case the user modified the graph after creation in
 some unforeseen way that could have introduced cycles, this function allows
 to force a check of acyclicity, if needed.

--- a/src/rust/src/graph/session.rs
+++ b/src/rust/src/graph/session.rs
@@ -28,6 +28,8 @@ pub enum GraphClass {
     Dag,
     /// Partially Directed Acyclic Graph (`-->`, `---`)
     Pdag,
+    /// Maximally Oriented Partially Directed Acyclic Graph (Meek-closed PDAG)
+    Mpdag,
     /// Undirected Graph (only `---`)
     Ug,
     /// Acyclic Directed Mixed Graph (`-->`, `<->`)
@@ -47,6 +49,7 @@ impl std::str::FromStr for GraphClass {
         match s.to_lowercase().as_str() {
             "dag" => Ok(GraphClass::Dag),
             "pdag" | "cpdag" => Ok(GraphClass::Pdag),
+            "mpdag" => Ok(GraphClass::Mpdag),
             "ug" => Ok(GraphClass::Ug),
             "admg" => Ok(GraphClass::Admg),
             "ag" | "mag" | "pag" => Ok(GraphClass::Ag),
@@ -62,6 +65,7 @@ impl GraphClass {
         match self {
             GraphClass::Dag => "DAG",
             GraphClass::Pdag => "PDAG",
+            GraphClass::Mpdag => "MPDAG",
             GraphClass::Ug => "UG",
             GraphClass::Admg => "ADMG",
             GraphClass::Ag => "AG",
@@ -480,6 +484,14 @@ impl GraphSession {
                 let pdag = Pdag::new(core).map_err(|e| self.map_error(e))?;
                 Ok(GraphView::Pdag(Arc::new(pdag)))
             }
+            GraphClass::Mpdag => {
+                let pdag = Pdag::new(core).map_err(|e| self.map_error(e))?;
+                if pdag.is_meek_closed() {
+                    Ok(GraphView::Pdag(Arc::new(pdag)))
+                } else {
+                    Err("graph is not MPDAG (not closed under Meek rules)".to_string())
+                }
+            }
             GraphClass::Ug => {
                 let ug = Ug::new(core).map_err(|e| self.map_error(e))?;
                 Ok(GraphView::Ug(Arc::new(ug)))
@@ -694,6 +706,14 @@ impl GraphSession {
                 Pdag::new(Arc::new(core.as_ref().clone())).map_err(|e| self.map_error(e))?;
                 Ok(GraphClass::Pdag)
             }
+            GraphClass::Mpdag => {
+                let pdag = Pdag::new(Arc::new(core.as_ref().clone())).map_err(|e| self.map_error(e))?;
+                if pdag.is_meek_closed() {
+                    Ok(GraphClass::Mpdag)
+                } else {
+                    Err("graph is not MPDAG (not closed under Meek rules)".to_string())
+                }
+            }
             GraphClass::Ug => {
                 Ug::new(Arc::new(core.as_ref().clone())).map_err(|e| self.map_error(e))?;
                 Ok(GraphClass::Ug)
@@ -712,8 +732,12 @@ impl GraphSession {
                     Ok(GraphClass::Dag)
                 } else if Ug::new(Arc::new(core.as_ref().clone())).is_ok() {
                     Ok(GraphClass::Ug)
-                } else if Pdag::new(Arc::new(core.as_ref().clone())).is_ok() {
-                    Ok(GraphClass::Pdag)
+                } else if let Ok(pdag) = Pdag::new(Arc::new(core.as_ref().clone())) {
+                    if pdag.is_meek_closed() {
+                        Ok(GraphClass::Mpdag)
+                    } else {
+                        Ok(GraphClass::Pdag)
+                    }
                 } else if Admg::new(Arc::new(core.as_ref().clone())).is_ok() {
                     Ok(GraphClass::Admg)
                 } else if Ag::new(Arc::new(core.as_ref().clone())).is_ok() {
@@ -1212,6 +1236,7 @@ mod tests {
     fn graph_class_from_str_and_as_str() {
         assert_eq!("dag".parse::<GraphClass>().unwrap(), GraphClass::Dag);
         assert_eq!("CPDAG".parse::<GraphClass>().unwrap(), GraphClass::Pdag);
+        assert_eq!("mpdag".parse::<GraphClass>().unwrap(), GraphClass::Mpdag);
         assert_eq!("ug".parse::<GraphClass>().unwrap(), GraphClass::Ug);
         assert_eq!("admg".parse::<GraphClass>().unwrap(), GraphClass::Admg);
         assert_eq!("mag".parse::<GraphClass>().unwrap(), GraphClass::Ag);
@@ -1221,6 +1246,7 @@ mod tests {
 
         assert_eq!(GraphClass::Dag.as_str(), "DAG");
         assert_eq!(GraphClass::Pdag.as_str(), "PDAG");
+        assert_eq!(GraphClass::Mpdag.as_str(), "MPDAG");
         assert_eq!(GraphClass::Ug.as_str(), "UG");
         assert_eq!(GraphClass::Admg.as_str(), "ADMG");
         assert_eq!(GraphClass::Ag.as_str(), "AG");
@@ -1514,6 +1540,23 @@ mod tests {
         assert_eq!(
             pdag.resolve_class(GraphClass::Auto).unwrap(),
             GraphClass::Pdag
+        );
+
+        let mut mpdag =
+            GraphSession::from_snapshot(Arc::clone(&snapshot), 3, true, GraphClass::Mpdag);
+        let mut mpdag_edges = EdgeBuffer::new();
+        mpdag_edges.push(0, 2, d);
+        mpdag_edges.push(1, 2, d);
+        mpdag.set_edges(mpdag_edges);
+        assert!(matches!(&*mpdag.view().unwrap(), GraphView::Pdag(_)));
+        assert_eq!(
+            mpdag.resolve_class(GraphClass::Mpdag).unwrap(),
+            GraphClass::Mpdag
+        );
+        assert_eq!(
+            mpdag.resolve_class(GraphClass::Auto).unwrap(),
+            // AUTO prioritizes DAG over (M)PDAG when both are valid.
+            GraphClass::Dag
         );
 
         let mut ug = GraphSession::from_snapshot(Arc::clone(&snapshot), 2, true, GraphClass::Ug);

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -553,8 +553,11 @@ fn graphview_new(core: ExternalPtr<CaugiGraph>, class: &str) -> ExternalPtr<Grap
             let dag = Dag::new(Arc::clone(&core_arc)).unwrap_or_else(|e| throw_r_error(e));
             ExternalPtr::new(GraphView::Dag(Arc::new(dag)))
         }
-        "PDAG" | "CPDAG" => {
+        "PDAG" | "CPDAG" | "MPDAG" => {
             let pdag = Pdag::new(Arc::clone(&core_arc)).unwrap_or_else(|e| throw_r_error(e));
+            if class.trim().eq_ignore_ascii_case("MPDAG") && !pdag.is_meek_closed() {
+                throw_r_error("graph is not MPDAG (not closed under Meek rules)");
+            }
             ExternalPtr::new(GraphView::Pdag(Arc::new(pdag)))
         }
         "UG" => {
@@ -595,8 +598,19 @@ fn graph_builder_resolve_class(mut b: ExternalPtr<GraphBuilder>, class: &str) ->
         .as_mut()
         .finalize_in_place()
         .unwrap_or_else(|e| throw_r_error(e));
-    let view = graphview_new(ExternalPtr::new(core), class);
-    graph_class_label_from_view(view.as_ref()).to_string()
+    let graph_class = GraphClass::from_str(class).unwrap_or_else(|e| throw_r_error(e));
+    let mut session = GraphSession::from_snapshot(
+        Arc::new(core.registry.clone()),
+        core.n(),
+        core.simple,
+        GraphClass::Unknown,
+    );
+    session.set_edges(edge_buffer_from_core(&core));
+    session
+        .resolve_class(graph_class)
+        .unwrap_or_else(|e| throw_r_error(e))
+        .as_str()
+        .to_string()
 }
 
 // ── Metrics ────────────────────────────────────────────────────────────────

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -545,6 +545,7 @@ fn graph_builder_add_edges(
 }
 
 // ── Constructors for class views ────────────────────────────────────────────────────────────────
+#[allow(dead_code)]
 fn graphview_new(core: ExternalPtr<CaugiGraph>, class: &str) -> ExternalPtr<GraphView> {
     let core_arc = Arc::new(core.as_ref().clone());
 

--- a/tests/testthat/test-as_caugi.R
+++ b/tests/testthat/test-as_caugi.R
@@ -69,6 +69,14 @@ test_that("matrix validation errors", {
   expect_error(as_caugi(z, class = "PAG"), "integer codes 0-3", fixed = TRUE)
 })
 
+test_that("MPDAG class is accepted for matrix conversion", {
+  m <- matrix(0L, 2, 2, dimnames = list(c("A", "B"), c("A", "B")))
+  m["A", "B"] <- 1L
+
+  cg <- as_caugi(m, class = "MPDAG")
+  expect_identical(cg@graph_class, "MPDAG")
+})
+
 test_that("logical matrices are accepted for non-PAG and rejected for PAG", {
   m <- matrix(FALSE, 2, 2)
   m[1, 2] <- TRUE

--- a/tests/testthat/test-caugi_graph.R
+++ b/tests/testthat/test-caugi_graph.R
@@ -265,6 +265,26 @@ test_that("building PDAG with bidirected edges results in error", {
   )
 })
 
+test_that("building MPDAG validates Meek closure", {
+  expect_s7_class(
+    caugi(
+      A %---% B,
+      A %-->% C,
+      B %-->% C,
+      class = "MPDAG"
+    ),
+    caugi
+  )
+
+  expect_error(
+    caugi(
+      A %-->% B,
+      B %---% C,
+      class = "MPDAG"
+    )
+  )
+})
+
 # ──────────────────────────────────────────────────────────────────────────────
 # ──────────────────────────────── AUTO tests ──────────────────────────────────
 # ──────────────────────────────────────────────────────────────────────────────
@@ -280,6 +300,8 @@ test_that("AUTO class picks the correct class", {
   expect_equal(cg@graph_class, "UNKNOWN")
   cg <- caugi(A %-->% B %---% C, class = "AUTO")
   expect_equal(cg@graph_class, "PDAG")
+  cg <- caugi(A %---% B, A %-->% C, B %-->% C, class = "AUTO")
+  expect_equal(cg@graph_class, "MPDAG")
 })
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/testthat/test-caugi_to.R
+++ b/tests/testthat/test-caugi_to.R
@@ -100,6 +100,22 @@ test_that("mixed edges: directed kept, undirected duplicated as bidirected", {
   expect_equal(nrow(ed), 5L)
 })
 
+test_that("MPDAG converts to igraph like PDAG", {
+  cg <- caugi(
+    A %---% B,
+    A %-->% C,
+    B %-->% C,
+    class = "MPDAG"
+  )
+  ig <- as_igraph(cg)
+  expect_true(igraph::is_directed(ig))
+  ed <- igraph::as_data_frame(ig)
+  expect_true(any(ed$from == "A" & ed$to == "C"))
+  expect_true(any(ed$from == "B" & ed$to == "C"))
+  expect_true(any(ed$from == "A" & ed$to == "B"))
+  expect_true(any(ed$from == "B" & ed$to == "A"))
+})
+
 test_that("conversion from UG --> igraph works", {
   cg <- caugi(A %---% B, class = "UG")
   ig <- as_igraph(cg)

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -205,6 +205,30 @@ test_that("mutate_caugi works from DAG to PDAG", {
   expect_equal(nodes(cg_pdag), nodes(cg_dag))
 })
 
+test_that("mutate_caugi supports MPDAG target when valid", {
+  cg_pdag <- caugi(
+    A %---% B,
+    A %-->% C,
+    B %-->% C,
+    class = "PDAG"
+  )
+  expect_true(is_mpdag(cg_pdag))
+  cg_mpdag <- mutate_caugi(cg_pdag, class = "MPDAG")
+  expect_equal(cg_mpdag@graph_class, "MPDAG")
+  expect_equal(edges(cg_mpdag), edges(cg_pdag))
+
+  cg_not_mpdag <- caugi(
+    A %-->% B,
+    B %---% C,
+    class = "PDAG"
+  )
+  expect_false(is_mpdag(cg_not_mpdag))
+  expect_error(
+    mutate_caugi(cg_not_mpdag, class = "MPDAG"),
+    "Cannot convert caugi"
+  )
+})
+
 test_that("mutate_caugi works from PDAG to DAG if PDAG is a DAG", {
   cg_pdag <- caugi(
     A %-->% B,
@@ -228,6 +252,10 @@ test_that("mutate_caugi works on empty caugi", {
   cg_empty_ug <- mutate_caugi(cg_empty, class = "UG")
   expect_equal(length(cg_empty_ug), 0)
   expect_equal(cg_empty_ug@graph_class, "UG")
+
+  cg_empty_mpdag <- mutate_caugi(cg_empty, class = "MPDAG")
+  expect_equal(length(cg_empty_mpdag), 0)
+  expect_equal(cg_empty_mpdag@graph_class, "MPDAG")
 })
 
 test_that("mutate_caugi doesn't change class if old class is equal to new class", {
@@ -637,7 +665,7 @@ test_that("dag_from_pdag errors on non-PDAG input", {
     B %-->% C,
     class = "DAG"
   )
-  expect_error(dag_from_pdag(cg), "Input must be a caugi PDAG graph")
+  expect_error(dag_from_pdag(cg), "Input must be a caugi PDAG/MPDAG graph")
 })
 
 test_that("dag_from_pdag errors if PDAG cannot be extended to a DAG", {

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -35,6 +35,17 @@ test_that("is_acyclic forces check when requested", {
   expect_true(is_acyclic(cg, force_check = TRUE))
 })
 
+test_that("is_acyclic fast path handles MPDAG class", {
+  cg <- caugi(
+    A %---% B,
+    A %-->% C,
+    B %-->% C,
+    class = "MPDAG"
+  )
+  expect_true(is_acyclic(cg))
+  expect_true(is_acyclic(cg, force_check = TRUE))
+})
+
 test_that("is_simple reflects declared state and force_check path", {
   cg_simple <- caugi(A %-->% B, class = "DAG")
   expect_true(is_simple(cg_simple))
@@ -272,6 +283,17 @@ test_that("is_mpdag tracks causal-learn style multi-rule progression", {
   expect_setequal(und_A, "B")
   expect_setequal(und_B, c("A", "C"))
   expect_setequal(und_C, "B")
+})
+
+test_that("is_pdag fast path handles MPDAG class", {
+  cg <- caugi(
+    A %---% B,
+    A %-->% C,
+    B %-->% C,
+    class = "MPDAG"
+  )
+  expect_true(is_pdag(cg))
+  expect_true(is_mpdag(cg))
 })
 
 test_that("is_cpdag rejects graphs where Meek R1 would fire", {


### PR DESCRIPTION
Add a new `MPDAG` class, which is a ergonomic way to represent a `PDAG` that fulfills Meek's rules. Right now, this is safe and always validates the graph. The intention is that we later on will be able to specialize behavior for this class, possibly leading to performance improvements since after validating we have stronger guarantees about the graph structure. We already have tests for `MPDAG`, and the functionality is already gated behind the `is_mpdag()` stuff we have already implemented, so hopefully this should be safe.