### PR TITLE
perf: rewrite `exogenize()` in Rust

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 - Improved performance of all queries. Speedups are more significant on larger graphs,
 but even on small graphs, queries are roughly 5x faster.
+- `exogenize()` is now implemented in Rust for DAGs, which reduces overhead on larger graphs.
 
 
 # caugi 1.1.0

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -122,6 +122,8 @@ rs_moralize <- function(session) .Call(wrap__rs_moralize, session)
 
 rs_latent_project <- function(session, latents) .Call(wrap__rs_latent_project, session, latents)
 
+rs_exogenize <- function(session, nodes) .Call(wrap__rs_exogenize, session, nodes)
+
 rs_induced_subgraph <- function(session, keep) .Call(wrap__rs_induced_subgraph, session, keep)
 
 subgraph <- function(cg, nodes, index) .Call(wrap__subgraph, cg, nodes, index)

--- a/R/operations.R
+++ b/R/operations.R
@@ -312,39 +312,11 @@ exogenize <- function(cg, nodes) {
     if (!u %in% all_nodes) {
       stop(paste0("Node ", u, " not in graph."), call. = FALSE)
     }
-
-    pa_u <- parents(cg, u) # NULL or character vector
-    ch_u <- children(cg, u) # NULL or character vector
-
-    # Step (i): add edges from every parent of u to every child of u
-    if (!is.null(pa_u) && !is.null(ch_u)) {
-      # cross-product of pa(u) x ch(u)
-      grid <- data.table::CJ(from = pa_u, to = ch_u, unique = TRUE)
-
-      # Avoid self-loops (l -> l)
-      grid <- grid[from != to]
-
-      if (nrow(grid) > 0L) {
-        cg <- add_edges(
-          cg,
-          from = grid$from,
-          edge = rep("-->", nrow(grid)),
-          to = grid$to
-        )
-      }
-    }
-
-    # Step (ii): delete incoming edges into u (l -> u)
-    if (!is.null(pa_u) && length(pa_u) > 0L) {
-      cg <- remove_edges(
-        cg,
-        from = pa_u,
-        to = rep(u, length(pa_u))
-      )
-    }
   }
 
-  cg
+  node_indices <- .nodes_to_indices(cg, nodes)
+  exogenized_session <- rs_exogenize(cg@session, node_indices)
+  .session_to_caugi(exogenized_session, node_names = all_nodes)
 }
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/rust/src/graph/dag/transforms.rs
+++ b/src/rust/src/graph/dag/transforms.rs
@@ -58,6 +58,106 @@ impl Dag {
         Ug::new(Arc::new(core))
     }
 
+    /// Exogenize a set of nodes in a DAG.
+    ///
+    /// For each selected node `u` in the supplied order:
+    /// 1. add directed edges `p -> c` for every `p ∈ Pa(u)` and `c ∈ Ch(u)` (excluding `p == c`)
+    /// 2. remove every incoming edge `p -> u`
+    pub fn exogenize(&self, nodes: &[u32]) -> Result<Dag, String> {
+        let n = self.n() as usize;
+
+        // Find directed edge code
+        let specs = &self.core_ref().registry.specs;
+        let mut dir_code: Option<u8> = None;
+        for (i, s) in specs.iter().enumerate() {
+            if matches!(s.class, EdgeClass::Directed) && (dir_code.is_none() || s.glyph == "-->") {
+                dir_code = Some(i as u8);
+            }
+        }
+        let dir = dir_code.ok_or("No Directed edge spec in registry")?;
+
+        // Mutable deterministic adjacency
+        let mut pa: Vec<BTreeSet<u32>> = vec![BTreeSet::new(); n];
+        let mut ch: Vec<BTreeSet<u32>> = vec![BTreeSet::new(); n];
+
+        for u in 0..self.n() {
+            for &c in self.children_of(u) {
+                ch[u as usize].insert(c);
+                pa[c as usize].insert(u);
+            }
+        }
+
+        fn add_dir(u: u32, v: u32, pa: &mut [BTreeSet<u32>], ch: &mut [BTreeSet<u32>]) {
+            if u == v {
+                return;
+            }
+            if ch[u as usize].insert(v) {
+                pa[v as usize].insert(u);
+            }
+        }
+
+        for &u in nodes {
+            if u >= self.n() {
+                return Err(format!("Index {} is out of bounds", u));
+            }
+            let ui = u as usize;
+
+            let parents_u: Vec<u32> = pa[ui].iter().copied().collect();
+            let children_u: Vec<u32> = ch[ui].iter().copied().collect();
+
+            for &p in &parents_u {
+                for &c in &children_u {
+                    add_dir(p, c, &mut pa, &mut ch);
+                }
+            }
+
+            for &p in &parents_u {
+                ch[p as usize].remove(&u);
+            }
+            pa[ui].clear();
+        }
+
+        let mut row_index = Vec::with_capacity(n + 1);
+        row_index.push(0u32);
+        for i in 0..n {
+            let c = pa[i].len() + ch[i].len();
+            row_index.push(row_index[i] + c as u32);
+        }
+
+        let nnz = *row_index.last().unwrap() as usize;
+        let mut col_index = vec![0u32; nnz];
+        let mut etype = vec![0u8; nnz];
+        let mut side = vec![0u8; nnz];
+        let mut cur = row_index[..n].to_vec();
+
+        for i in 0..n {
+            for &p in pa[i].iter() {
+                let k = cur[i] as usize;
+                col_index[k] = p;
+                etype[k] = dir;
+                side[k] = 1;
+                cur[i] += 1;
+            }
+            for &c in ch[i].iter() {
+                let k = cur[i] as usize;
+                col_index[k] = c;
+                etype[k] = dir;
+                side[k] = 0;
+                cur[i] += 1;
+            }
+        }
+
+        let core = CaugiGraph::from_csr(
+            row_index,
+            col_index,
+            etype,
+            side,
+            /*simple=*/ true,
+            self.core_ref().registry.clone(),
+        )?;
+        Dag::new(Arc::new(core))
+    }
+
     /// Project out latent variables from a DAG to produce an ADMG.
     ///
     /// Uses the vertex elimination algorithm for latent projection:
@@ -491,6 +591,41 @@ mod tests {
         assert_eq!(ug.neighbors_of(0), &[1, 2]);
         assert_eq!(ug.neighbors_of(1), &[0, 2]);
         assert_eq!(ug.neighbors_of(2), &[0, 1]);
+    }
+
+    #[test]
+    fn dag_exogenize_basic() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let d = reg.code_of("-->").unwrap();
+        let mut b = GraphBuilder::new_with_registry(3, true, &reg);
+        b.add_edge(0, 1, d).unwrap(); // A -> B
+        b.add_edge(1, 2, d).unwrap(); // B -> C
+        let dag = Dag::new(Arc::new(b.finalize().unwrap())).unwrap();
+
+        let exo = dag.exogenize(&[1]).unwrap();
+        assert_eq!(exo.parents_of(0), Vec::<u32>::new());
+        assert_eq!(exo.parents_of(1), Vec::<u32>::new());
+        assert_eq!(exo.parents_of(2), vec![0, 1]); // A -> C added, B -> C kept
+    }
+
+    #[test]
+    fn dag_exogenize_duplicate_nodes_are_idempotent() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let d = reg.code_of("-->").unwrap();
+        let mut b = GraphBuilder::new_with_registry(3, true, &reg);
+        b.add_edge(0, 1, d).unwrap();
+        b.add_edge(1, 2, d).unwrap();
+        let dag = Dag::new(Arc::new(b.finalize().unwrap())).unwrap();
+
+        let exo_once = dag.exogenize(&[1]).unwrap();
+        let exo_twice = dag.exogenize(&[1, 1]).unwrap();
+
+        for i in 0..3 {
+            assert_eq!(exo_once.parents_of(i), exo_twice.parents_of(i));
+            assert_eq!(exo_once.children_of(i), exo_twice.children_of(i));
+        }
     }
 
     #[test]

--- a/src/rust/src/graph/session.rs
+++ b/src/rust/src/graph/session.rs
@@ -351,7 +351,8 @@ impl GraphSession {
     }
 
     pub fn replace_edges_for_pairs(&mut self, new_edges: EdgeBuffer) {
-        let mut remove_pairs: FxHashSet<(u32, u32)> = FxHashSet::with_capacity_and_hasher(new_edges.len(), Default::default());
+        let mut remove_pairs: FxHashSet<(u32, u32)> =
+            FxHashSet::with_capacity_and_hasher(new_edges.len(), Default::default());
         if self.simple {
             for i in 0..new_edges.len() {
                 let u = new_edges.from[i];
@@ -366,8 +367,10 @@ impl GraphSession {
         }
 
         let mut kept = EdgeBuffer::with_capacity(self.edges.len() + new_edges.len());
-        let mut seen: FxHashSet<(u32, u32, u8)> =
-            FxHashSet::with_capacity_and_hasher(self.edges.len() + new_edges.len(), Default::default());
+        let mut seen: FxHashSet<(u32, u32, u8)> = FxHashSet::with_capacity_and_hasher(
+            self.edges.len() + new_edges.len(),
+            Default::default(),
+        );
 
         for i in 0..self.edges.len() {
             let u = self.edges.from[i];
@@ -755,6 +758,12 @@ impl GraphSession {
     pub fn latent_project(&mut self, latents: &[u32]) -> Result<GraphView, String> {
         let view = self.view()?;
         view.latent_project(latents).map_err(|e| self.map_error(e))
+    }
+
+    /// Exogenize a set of nodes (DAG only).
+    pub fn exogenize(&mut self, nodes: &[u32]) -> Result<GraphView, String> {
+        let view = self.view()?;
+        view.exogenize(nodes).map_err(|e| self.map_error(e))
     }
 
     /// D-separation query (DAG only).

--- a/src/rust/src/graph/view.rs
+++ b/src/rust/src/graph/view.rs
@@ -551,6 +551,16 @@ impl GraphView {
         }
     }
 
+    pub fn exogenize(&self, nodes: &[u32]) -> Result<GraphView, String> {
+        match self {
+            GraphView::Dag(d) => {
+                let out = d.exogenize(nodes)?;
+                Ok(GraphView::Dag(Arc::new(out)))
+            }
+            _ => Err("exogenize is only defined for DAGs".into()),
+        }
+    }
+
     /// Proper backdoor graph for Xs → Ys. Defined for DAG only.
     pub fn proper_backdoor_graph(&self, xs: &[u32], ys: &[u32]) -> Result<GraphView, String> {
         match self {

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1623,6 +1623,25 @@ fn rs_latent_project(
     ExternalPtr::new(session_from_view(view, names))
 }
 
+#[extendr]
+fn rs_exogenize(
+    mut session: ExternalPtr<GraphSession>,
+    nodes: Integers,
+) -> ExternalPtr<GraphSession> {
+    let nodes_u: Vec<u32> = nodes.iter().map(|ri| rint_to_u32(ri, "nodes")).collect();
+    for &i in &nodes_u {
+        if i >= session.as_ref().n() {
+            throw_r_error(format!("Index {} is out of bounds", i));
+        }
+    }
+    let view = session
+        .as_mut()
+        .exogenize(&nodes_u)
+        .unwrap_or_else(|e| throw_r_error(e));
+    let names: Vec<String> = session.as_ref().names().to_vec();
+    ExternalPtr::new(session_from_view(view, names))
+}
+
 fn induced_subgraph_session_from_keep(
     session: &mut ExternalPtr<GraphSession>,
     keep_u: &[u32],
@@ -2046,6 +2065,7 @@ extendr_module! {
     fn rs_skeleton;
     fn rs_moralize;
     fn rs_latent_project;
+    fn rs_exogenize;
     fn rs_induced_subgraph;
     fn subgraph;
     fn rs_d_separated;

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -512,6 +512,35 @@ test_that("exogenize agrees with exogenous query", {
   )
 })
 
+test_that("exogenize supports multiple nodes", {
+  cg <- caugi(
+    A %-->% B,
+    B %-->% C,
+    C %-->% D,
+    class = "DAG"
+  )
+  exogenized_cg <- exogenize(cg, nodes = c("B", "C"))
+
+  expect_null(parents(exogenized_cg, "B"))
+  expect_null(parents(exogenized_cg, "C"))
+  expect_setequal(parents(exogenized_cg, "D"), c("B", "C", "A"))
+})
+
+test_that("exogenize handles duplicate node inputs", {
+  cg <- caugi(
+    A %-->% B,
+    B %-->% C,
+    class = "DAG"
+  )
+
+  exo_once <- exogenize(cg, nodes = "B")
+  exo_twice <- exogenize(cg, nodes = c("B", "B"))
+
+  actual_once <- edges(exo_once)[order(from, to, edge)]
+  actual_twice <- edges(exo_twice)[order(from, to, edge)]
+  expect_equal(actual_once, actual_twice)
+})
+
 test_that("exogenize fails with non-simple graphs", {
   cg <- caugi(
     A %-->% B,


### PR DESCRIPTION
This PR implements `exogenize()` in Rust instead, to improve performance.

``` r
library(caugi)

# old implementation
exogenize_reference_r <- function(cg, nodes) {
  all_nodes <- nodes(cg)$name

  for (u in nodes) {
    if (!u %in% all_nodes) {
      stop(paste0("Node ", u, " not in graph."), call. = FALSE)
    }

    pa_u <- parents(cg, u)
    ch_u <- children(cg, u)

    if (!is.null(pa_u) && !is.null(ch_u)) {
      grid <- data.table::CJ(from = pa_u, to = ch_u, unique = TRUE)
      grid <- grid[from != to]

      if (nrow(grid) > 0L) {
        cg <- add_edges(
          cg,
          from = grid$from,
          edge = rep("-->", nrow(grid)),
          to = grid$to
        )
      }
    }

    if (!is.null(pa_u) && length(pa_u) > 0L) {
      cg <- remove_edges(
        cg,
        from = pa_u,
        to = rep(u, length(pa_u))
      )
    }
  }

  cg
}

benchmark_exogenize <- function(
  n = c(100, 200, 500),
  p = c(0.5, 0.9),
  latent_share = 0.1
) {
  bench::press(
    n = n,
    p = p,
    {
      p_mod <- 10 * log10(n) / n * p
      cg <- caugi::generate_graph(n = n, p = p_mod, class = "DAG")
      k <- max(1L, as.integer(round(latent_share * n)))
      target_nodes <- sample(caugi::nodes(cg)$name, size = k)

      bench::mark(
        rust = caugi::exogenize(cg, nodes = target_nodes),
        reference_r = exogenize_reference_r(cg, nodes = target_nodes)
      )
    },
    .quiet = TRUE
  )
}

benchmark_exogenize() |> plot()
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
```

![](https://i.imgur.com/UEHyEJO.png)<!-- -->

<sup>Created on 2026-04-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>