### PR TITLE
perf: rewrite normalize_latent_structure() in Rust

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - Improved performance of all queries. Speedups are more significant on larger graphs,
 but even on small graphs, queries are roughly 5x faster.
 - `exogenize()` is now implemented in Rust for DAGs, which reduces overhead on larger graphs.
+- `normalize_latent_structure()` is now implemented in Rust for DAGs for faster latent normalization workflows.
 
 
 # caugi 1.1.0

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -124,6 +124,8 @@ rs_latent_project <- function(session, latents) .Call(wrap__rs_latent_project, s
 
 rs_exogenize <- function(session, nodes) .Call(wrap__rs_exogenize, session, nodes)
 
+rs_normalize_latent_structure <- function(session, latents) .Call(wrap__rs_normalize_latent_structure, session, latents)
+
 rs_induced_subgraph <- function(session, keep) .Call(wrap__rs_induced_subgraph, session, keep)
 
 subgraph <- function(cg, nodes, index) .Call(wrap__subgraph, cg, nodes, index)

--- a/R/operations.R
+++ b/R/operations.R
@@ -401,90 +401,12 @@ normalize_latent_structure <- function(cg, latents) {
     )
   }
 
-  cg <- exogenize(cg, nodes = latents)
-
-  changed <- TRUE
-
-  while (changed) {
-    changed <- FALSE
-    current_latents <- intersect(latents, nodes(cg)$name)
-
-    if (length(current_latents) == 0L) {
-      break
-    }
-
-    # Lemma 3: remove exogenous latents with <= 1 child
-    child_counts <- vapply(
-      current_latents,
-      function(l) {
-        ch <- children(cg, l)
-
-        if (is.null(ch)) {
-          0L
-        } else {
-          length(ch)
-        }
-      },
-      integer(1)
-    )
-
-    to_drop <- current_latents[child_counts <= 1L]
-
-    if (length(to_drop) > 0L) {
-      cg <- remove_nodes(cg, name = to_drop)
-      changed <- TRUE
-      next
-    }
-
-    # Lemma 2: remove nested child sets among exogenous latents
-    current_latents <- intersect(latents, nodes(cg)$name)
-
-    if (length(current_latents) < 2L) {
-      break
-    }
-
-    child_sets <- lapply(
-      current_latents,
-      function(l) {
-        ch <- children(cg, l)
-        if (is.null(ch)) {
-          character(0)
-        } else {
-          sort(unique(ch))
-        }
-      }
-    )
-
-    drop_one <- NULL
-
-    for (i in seq_len(length(current_latents) - 1L)) {
-      for (j in (i + 1L):length(current_latents)) {
-        ch_i <- child_sets[[i]]
-        ch_j <- child_sets[[j]]
-
-        if (length(ch_i) < length(ch_j) && all(ch_i %in% ch_j)) {
-          drop_one <- current_latents[i]
-          break
-        }
-
-        if (length(ch_j) < length(ch_i) && all(ch_j %in% ch_i)) {
-          drop_one <- current_latents[j]
-          break
-        }
-      }
-
-      if (!is.null(drop_one)) {
-        break
-      }
-    }
-
-    if (!is.null(drop_one)) {
-      cg <- remove_nodes(cg, name = drop_one)
-      changed <- TRUE
-    }
-  }
-
-  cg
+  latent_indices <- .nodes_to_indices(cg, latents)
+  normalized_session <- rs_normalize_latent_structure(
+    cg@session,
+    latent_indices
+  )
+  .session_to_caugi(normalized_session)
 }
 
 

--- a/src/rust/src/graph/dag/transforms.rs
+++ b/src/rust/src/graph/dag/transforms.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-//! Graph transformations for DAGs: skeleton, moralize, to_cpdag, latent_project.
+//! Graph transformations for DAGs.
 
 use super::Dag;
 use crate::edges::EdgeClass;
@@ -156,6 +156,235 @@ impl Dag {
             self.core_ref().registry.clone(),
         )?;
         Dag::new(Arc::new(core))
+    }
+
+    /// Normalize latent structure in a DAG for a given latent set.
+    ///
+    /// Applies:
+    /// 1) exogenization of all latent nodes,
+    /// 2) iterative removal of latent nodes with <= 1 child,
+    /// 3) iterative removal of one latent node whose child set is a strict subset
+    ///    of another latent node's child set.
+    ///
+    /// Returns the normalized DAG and the original indices of nodes kept.
+    pub fn normalize_latent_structure(&self, latents: &[u32]) -> Result<(Dag, Vec<u32>), String> {
+        let n = self.n() as usize;
+        let specs = &self.core_ref().registry.specs;
+        let mut dir_code: Option<u8> = None;
+        for (i, s) in specs.iter().enumerate() {
+            if matches!(s.class, EdgeClass::Directed) && (dir_code.is_none() || s.glyph == "-->") {
+                dir_code = Some(i as u8);
+            }
+        }
+        let dir = dir_code.ok_or("No Directed edge spec in registry")?;
+
+        // Mutable deterministic adjacency over original node indices.
+        let mut pa: Vec<BTreeSet<u32>> = vec![BTreeSet::new(); n];
+        let mut ch: Vec<BTreeSet<u32>> = vec![BTreeSet::new(); n];
+        let mut active = vec![true; n];
+
+        for u in 0..self.n() {
+            for &c in self.children_of(u) {
+                ch[u as usize].insert(c);
+                pa[c as usize].insert(u);
+            }
+        }
+
+        fn add_dir(u: u32, v: u32, pa: &mut [BTreeSet<u32>], ch: &mut [BTreeSet<u32>]) {
+            if u == v {
+                return;
+            }
+            if ch[u as usize].insert(v) {
+                pa[v as usize].insert(u);
+            }
+        }
+
+        fn remove_node(
+            u: u32,
+            active: &mut [bool],
+            pa: &mut [BTreeSet<u32>],
+            ch: &mut [BTreeSet<u32>],
+        ) {
+            let ui = u as usize;
+            if !active[ui] {
+                return;
+            }
+            let parents_u: Vec<u32> = pa[ui].iter().copied().collect();
+            let children_u: Vec<u32> = ch[ui].iter().copied().collect();
+
+            for p in parents_u {
+                ch[p as usize].remove(&u);
+            }
+            for c in children_u {
+                pa[c as usize].remove(&u);
+            }
+            pa[ui].clear();
+            ch[ui].clear();
+            active[ui] = false;
+        }
+
+        // Step 1: Exogenize all latents in input order.
+        for &u in latents {
+            if u >= self.n() {
+                return Err(format!("Index {} is out of bounds", u));
+            }
+            if !active[u as usize] {
+                continue;
+            }
+            let ui = u as usize;
+            let parents_u: Vec<u32> = pa[ui].iter().copied().collect();
+            let children_u: Vec<u32> = ch[ui].iter().copied().collect();
+
+            for &p in &parents_u {
+                for &c in &children_u {
+                    add_dir(p, c, &mut pa, &mut ch);
+                }
+            }
+            for &p in &parents_u {
+                ch[p as usize].remove(&u);
+            }
+            pa[ui].clear();
+        }
+
+        // Steps 2-3: iterate until stable.
+        let mut changed = true;
+        while changed {
+            changed = false;
+
+            let current_latents: Vec<u32> = latents
+                .iter()
+                .copied()
+                .filter(|&u| (u as usize) < active.len() && active[u as usize])
+                .collect();
+
+            if current_latents.is_empty() {
+                break;
+            }
+
+            // Step 2: remove all active latents with <= 1 child.
+            let to_drop: Vec<u32> = current_latents
+                .iter()
+                .copied()
+                .filter(|&u| {
+                    ch[u as usize]
+                        .iter()
+                        .filter(|&&v| active[v as usize])
+                        .count()
+                        <= 1usize
+                })
+                .collect();
+
+            if !to_drop.is_empty() {
+                for u in to_drop {
+                    remove_node(u, &mut active, &mut pa, &mut ch);
+                }
+                changed = true;
+                continue;
+            }
+
+            // Step 3: remove one latent whose child set is a strict subset of another.
+            if current_latents.len() < 2 {
+                break;
+            }
+
+            let child_sets: Vec<Vec<u32>> = current_latents
+                .iter()
+                .map(|&u| {
+                    ch[u as usize]
+                        .iter()
+                        .copied()
+                        .filter(|&v| active[v as usize])
+                        .collect::<Vec<u32>>()
+                })
+                .collect();
+
+            let mut drop_one: Option<u32> = None;
+            'outer: for i in 0..(current_latents.len() - 1) {
+                for j in (i + 1)..current_latents.len() {
+                    let ch_i = &child_sets[i];
+                    let ch_j = &child_sets[j];
+                    if ch_i.len() < ch_j.len() && ch_i.iter().all(|x| ch_j.binary_search(x).is_ok())
+                    {
+                        drop_one = Some(current_latents[i]);
+                        break 'outer;
+                    }
+                    if ch_j.len() < ch_i.len() && ch_j.iter().all(|x| ch_i.binary_search(x).is_ok())
+                    {
+                        drop_one = Some(current_latents[j]);
+                        break 'outer;
+                    }
+                }
+            }
+
+            if let Some(u) = drop_one {
+                remove_node(u, &mut active, &mut pa, &mut ch);
+                changed = true;
+            }
+        }
+
+        let kept_old: Vec<u32> = (0..self.n()).filter(|&u| active[u as usize]).collect();
+        let m = kept_old.len();
+        let mut old_to_new: Vec<Option<u32>> = vec![None; n];
+        for (new_i, &old_i) in kept_old.iter().enumerate() {
+            old_to_new[old_i as usize] = Some(new_i as u32);
+        }
+
+        let mut row_index = Vec::with_capacity(m + 1);
+        row_index.push(0u32);
+        for &old_i in &kept_old {
+            let oi = old_i as usize;
+            let pa_ct = pa[oi]
+                .iter()
+                .filter(|&&p| old_to_new[p as usize].is_some())
+                .count() as u32;
+            let ch_ct = ch[oi]
+                .iter()
+                .filter(|&&c| old_to_new[c as usize].is_some())
+                .count() as u32;
+            let last = *row_index
+                .last()
+                .expect("row_index has at least one element");
+            row_index.push(last + pa_ct + ch_ct);
+        }
+
+        let nnz = *row_index.last().unwrap_or(&0u32) as usize;
+        let mut col_index = vec![0u32; nnz];
+        let mut etype = vec![0u8; nnz];
+        let mut side = vec![0u8; nnz];
+        let mut cur = row_index[..m].to_vec();
+
+        for (new_i, &old_i) in kept_old.iter().enumerate() {
+            let oi = old_i as usize;
+            for &p in pa[oi].iter() {
+                if let Some(np) = old_to_new[p as usize] {
+                    let k = cur[new_i] as usize;
+                    col_index[k] = np;
+                    etype[k] = dir;
+                    side[k] = 1;
+                    cur[new_i] += 1;
+                }
+            }
+            for &c in ch[oi].iter() {
+                if let Some(nc) = old_to_new[c as usize] {
+                    let k = cur[new_i] as usize;
+                    col_index[k] = nc;
+                    etype[k] = dir;
+                    side[k] = 0;
+                    cur[new_i] += 1;
+                }
+            }
+        }
+
+        let core = CaugiGraph::from_csr(
+            row_index,
+            col_index,
+            etype,
+            side,
+            /*simple=*/ true,
+            self.core_ref().registry.clone(),
+        )?;
+        let dag = Dag::new(Arc::new(core))?;
+        Ok((dag, kept_old))
     }
 
     /// Project out latent variables from a DAG to produce an ADMG.
@@ -626,6 +855,44 @@ mod tests {
             assert_eq!(exo_once.parents_of(i), exo_twice.parents_of(i));
             assert_eq!(exo_once.children_of(i), exo_twice.children_of(i));
         }
+    }
+
+    #[test]
+    fn dag_normalize_latent_structure_drops_singleton_latent() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let d = reg.code_of("-->").unwrap();
+        // U -> X
+        let mut b = GraphBuilder::new_with_registry(2, true, &reg);
+        b.add_edge(0, 1, d).unwrap();
+        let dag = Dag::new(Arc::new(b.finalize().unwrap())).unwrap();
+
+        let (norm, kept_old) = dag.normalize_latent_structure(&[0]).unwrap();
+        assert_eq!(norm.n(), 1);
+        assert_eq!(kept_old, vec![1]);
+        assert!(norm.parents_of(0).is_empty());
+        assert!(norm.children_of(0).is_empty());
+    }
+
+    #[test]
+    fn dag_normalize_latent_structure_drops_nested_child_set() {
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let d = reg.code_of("-->").unwrap();
+        // U -> X,Y,Z and W -> X,Y where latents are [U,W]
+        // W child set is strict subset of U, so W is dropped.
+        // node order: U=0, W=1, X=2, Y=3, Z=4
+        let mut b = GraphBuilder::new_with_registry(5, true, &reg);
+        b.add_edge(0, 2, d).unwrap();
+        b.add_edge(0, 3, d).unwrap();
+        b.add_edge(0, 4, d).unwrap();
+        b.add_edge(1, 2, d).unwrap();
+        b.add_edge(1, 3, d).unwrap();
+        let dag = Dag::new(Arc::new(b.finalize().unwrap())).unwrap();
+
+        let (norm, kept_old) = dag.normalize_latent_structure(&[0, 1]).unwrap();
+        assert_eq!(norm.n(), 4);
+        assert_eq!(kept_old, vec![0, 2, 3, 4]); // W removed
     }
 
     #[test]

--- a/src/rust/src/graph/session.rs
+++ b/src/rust/src/graph/session.rs
@@ -790,6 +790,16 @@ impl GraphSession {
         view.exogenize(nodes).map_err(|e| self.map_error(e))
     }
 
+    /// Normalize latent structure (DAG only).
+    pub fn normalize_latent_structure(
+        &mut self,
+        latents: &[u32],
+    ) -> Result<(GraphView, Vec<u32>), String> {
+        let view = self.view()?;
+        view.normalize_latent_structure(latents)
+            .map_err(|e| self.map_error(e))
+    }
+
     /// D-separation query (DAG only).
     pub fn d_separated(&mut self, xs: &[u32], ys: &[u32], z: &[u32]) -> Result<bool, String> {
         let view = self.view()?;

--- a/src/rust/src/graph/view.rs
+++ b/src/rust/src/graph/view.rs
@@ -561,6 +561,19 @@ impl GraphView {
         }
     }
 
+    pub fn normalize_latent_structure(
+        &self,
+        latents: &[u32],
+    ) -> Result<(GraphView, Vec<u32>), String> {
+        match self {
+            GraphView::Dag(d) => {
+                let (out, kept_old) = d.normalize_latent_structure(latents)?;
+                Ok((GraphView::Dag(Arc::new(out)), kept_old))
+            }
+            _ => Err("normalize_latent_structure is only defined for DAGs".into()),
+        }
+    }
+
     /// Proper backdoor graph for Xs → Ys. Defined for DAG only.
     pub fn proper_backdoor_graph(&self, xs: &[u32], ys: &[u32]) -> Result<GraphView, String> {
         match self {

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1657,6 +1657,31 @@ fn rs_exogenize(
     ExternalPtr::new(session_from_view(view, names))
 }
 
+#[extendr]
+fn rs_normalize_latent_structure(
+    mut session: ExternalPtr<GraphSession>,
+    latents: Integers,
+) -> ExternalPtr<GraphSession> {
+    let latents_u: Vec<u32> = latents
+        .iter()
+        .map(|ri| rint_to_u32(ri, "latents"))
+        .collect();
+    for &i in &latents_u {
+        if i >= session.as_ref().n() {
+            throw_r_error(format!("Index {} is out of bounds", i));
+        }
+    }
+    let (view, keep_old) = session
+        .as_mut()
+        .normalize_latent_structure(&latents_u)
+        .unwrap_or_else(|e| throw_r_error(e));
+    let names: Vec<String> = keep_old
+        .iter()
+        .map(|&old_i| session.as_ref().names()[old_i as usize].clone())
+        .collect();
+    ExternalPtr::new(session_from_view(view, names))
+}
+
 fn induced_subgraph_session_from_keep(
     session: &mut ExternalPtr<GraphSession>,
     keep_u: &[u32],
@@ -2081,6 +2106,7 @@ extendr_module! {
     fn rs_moralize;
     fn rs_latent_project;
     fn rs_exogenize;
+    fn rs_normalize_latent_structure;
     fn rs_induced_subgraph;
     fn subgraph;
     fn rs_d_separated;

--- a/tests/testthat/test-normalize-latent-structure.R
+++ b/tests/testthat/test-normalize-latent-structure.R
@@ -94,6 +94,89 @@ test_that("normalize_latent_structure is idempotent", {
   expect_equal(shd(norm1, norm2), 0)
 })
 
+test_that("normalize_latent_structure matches R reference implementation", {
+  normalize_reference_r <- function(cg, latents) {
+    latents <- unique(latents)
+    if (length(latents) == 0L) {
+      return(cg)
+    }
+    cg <- exogenize(cg, nodes = latents)
+
+    changed <- TRUE
+    while (changed) {
+      changed <- FALSE
+      current_latents <- intersect(latents, nodes(cg)$name)
+      if (length(current_latents) == 0L) {
+        break
+      }
+
+      child_counts <- vapply(
+        current_latents,
+        function(l) {
+          ch <- children(cg, l)
+          if (is.null(ch)) 0L else length(ch)
+        },
+        integer(1)
+      )
+      to_drop <- current_latents[child_counts <= 1L]
+      if (length(to_drop) > 0L) {
+        cg <- remove_nodes(cg, name = to_drop)
+        changed <- TRUE
+        next
+      }
+
+      current_latents <- intersect(latents, nodes(cg)$name)
+      if (length(current_latents) < 2L) {
+        break
+      }
+
+      child_sets <- lapply(
+        current_latents,
+        function(l) {
+          ch <- children(cg, l)
+          if (is.null(ch)) character(0) else sort(unique(ch))
+        }
+      )
+
+      drop_one <- NULL
+      for (i in seq_len(length(current_latents) - 1L)) {
+        for (j in (i + 1L):length(current_latents)) {
+          ch_i <- child_sets[[i]]
+          ch_j <- child_sets[[j]]
+          if (length(ch_i) < length(ch_j) && all(ch_i %in% ch_j)) {
+            drop_one <- current_latents[i]
+            break
+          }
+          if (length(ch_j) < length(ch_i) && all(ch_j %in% ch_i)) {
+            drop_one <- current_latents[j]
+            break
+          }
+        }
+        if (!is.null(drop_one)) {
+          break
+        }
+      }
+
+      if (!is.null(drop_one)) {
+        cg <- remove_nodes(cg, name = drop_one)
+        changed <- TRUE
+      }
+    }
+
+    cg
+  }
+
+  set.seed(42)
+  dag <- generate_graph(n = 80, m = 8, class = "DAG")
+  latents <- sample(nodes(dag)$name, size = 12)
+
+  rust_norm <- normalize_latent_structure(dag, latents = latents)
+  ref_norm <- normalize_reference_r(dag, latents = latents)
+
+  expect_equal(shd(rust_norm, ref_norm), 0)
+  expect_setequal(nodes(rust_norm)$name, nodes(ref_norm)$name)
+})
+
 test_that("normalize_latent_structure validation and loop branches are covered", {
   cg_pdag <- caugi(A %---% B, class = "PDAG")
   expect_error(
@@ -130,23 +213,10 @@ test_that("normalize_latent_structure validation and loop branches are covered",
     "U1" %in% out_nested@nodes$name && "U2" %in% out_nested@nodes$name
   )
 
-  # Force child_sets NULL branch in Lemma 2 (coverage for character(0) path).
-  dag_mock <- caugi(
-    U1 %-->% X + Y,
-    U2 %-->% X + Y,
-    class = "DAG"
+  # Empty/overlap branch behavior.
+  overlap <- normalize_latent_structure(
+    caugi(U1 %-->% X + Y, U2 %-->% X + Y, class = "DAG"),
+    latents = c("U1", "U2")
   )
-  normalize_for_null_children <- normalize_latent_structure
-  environment(normalize_for_null_children) <- list2env(
-    list(
-      vapply = function(X, FUN, FUN.VALUE, ..., USE.NAMES = TRUE) {
-        rep.int(2L, length(X))
-      },
-      children = function(cg, l) NULL
-    ),
-    parent = environment(normalize_latent_structure)
-  )
-  expect_silent(
-    normalize_for_null_children(dag_mock, latents = c("U1", "U2"))
-  )
+  expect_true(all(c("U1", "U2") %in% nodes(overlap)$name))
 })


### PR DESCRIPTION
Implement `normalize_latent_structure()` in Rust instead to improve
performance. This change is stacked on top of https://github.com/frederikfabriciusbjerre/caugi/pull/268, which needs to be merged first.


``` r
library(caugi)

# Old implementation
normalize_latent_structure_reference_r <- function(cg, latents) {
  latents <- unique(latents)

  if (length(latents) == 0L) {
    return(cg)
  }

  cg <- exogenize(cg, nodes = latents)

  changed <- TRUE
  while (changed) {
    changed <- FALSE
    current_latents <- intersect(latents, nodes(cg)$name)

    if (length(current_latents) == 0L) {
      break
    }

    child_counts <- vapply(
      current_latents,
      function(l) {
        ch <- children(cg, l)
        if (is.null(ch)) 0L else length(ch)
      },
      integer(1)
    )
    to_drop <- current_latents[child_counts <= 1L]

    if (length(to_drop) > 0L) {
      cg <- remove_nodes(cg, name = to_drop)
      changed <- TRUE
      next
    }

    current_latents <- intersect(latents, nodes(cg)$name)
    if (length(current_latents) < 2L) {
      break
    }

    child_sets <- lapply(
      current_latents,
      function(l) {
        ch <- children(cg, l)
        if (is.null(ch)) character(0) else sort(unique(ch))
      }
    )

    drop_one <- NULL
    for (i in seq_len(length(current_latents) - 1L)) {
      for (j in (i + 1L):length(current_latents)) {
        ch_i <- child_sets[[i]]
        ch_j <- child_sets[[j]]

        if (length(ch_i) < length(ch_j) && all(ch_i %in% ch_j)) {
          drop_one <- current_latents[i]
          break
        }
        if (length(ch_j) < length(ch_i) && all(ch_j %in% ch_i)) {
          drop_one <- current_latents[j]
          break
        }
      }
      if (!is.null(drop_one)) {
        break
      }
    }

    if (!is.null(drop_one)) {
      cg <- remove_nodes(cg, name = drop_one)
      changed <- TRUE
    }
  }

  cg
}

bench::press(
  n = c(100, 200),
  p = c(0.5, 0.9),
  {
    p_mod <- 10 * log10(n) / n * p
    cg <- caugi::generate_graph(n = n, p = p_mod, class = "DAG")
    k <- max(2L, as.integer(round(0.1 * n)))
    latents <- sample(caugi::nodes(cg)$name, size = k)

    bench::mark(
      rust = caugi::normalize_latent_structure(cg, latents = latents),
      reference_r = normalize_latent_structure_reference_r(
        cg,
        latents = latents
      )
    )
  }
) |>
  plot()
#> Running with:
#>       n     p
#> 1   100   0.5
#> 2   200   0.5
#> 3   100   0.9
#> 4   200   0.9
```

![](https://i.imgur.com/iHUbEvY.png)<!-- -->

<sup>Created on 2026-04-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>