### PR TITLE
perf: rewrite `not_m_separated_for_all_subsets()` in Rust

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -134,6 +134,8 @@ rs_minimal_d_separator <- function(session, xs, ys, include, restrict) .Call(wra
 
 rs_m_separated <- function(session, xs, ys, z) .Call(wrap__rs_m_separated, session, xs, ys, z)
 
+rs_not_m_separated_for_all_subsets <- function(session, node_a, node_b, other_nodes, cond_vars) .Call(wrap__rs_not_m_separated_for_all_subsets, session, node_a, node_b, other_nodes, cond_vars)
+
 rs_adjustment_set_parents <- function(session, xs, ys) .Call(wrap__rs_adjustment_set_parents, session, xs, ys)
 
 rs_adjustment_set_backdoor <- function(session, xs, ys) .Call(wrap__rs_adjustment_set_backdoor, session, xs, ys)

--- a/R/operations.R
+++ b/R/operations.R
@@ -643,45 +643,25 @@ condition_marginalize <- function(cg, cond_vars = NULL, marg_vars = NULL) {
   other_nodes,
   cond_vars
 ) {
-  n_other <- length(other_nodes)
-
-  # Generate all subsets of other_nodes
-  subsets <- if (n_other == 0L) {
-    list(NULL)
+  node_idx <- .nodes_to_indices(cg, c(node_a, node_b))
+  other_idx <- if (length(other_nodes) == 0L) {
+    integer(0)
   } else {
-    # Build subsets from largest to smallest (often finds separation faster)
-    c(
-      list(other_nodes),
-      if (n_other > 1L) {
-        unlist(
-          lapply(
-            seq_len(n_other - 1L),
-            function(k) combn(other_nodes, n_other - k, simplify = FALSE)
-          ),
-          recursive = FALSE
-        )
-      },
-      list(NULL)
-    )
+    .nodes_to_indices(cg, other_nodes)
+  }
+  cond_idx <- if (length(cond_vars) == 0L) {
+    integer(0)
+  } else {
+    .nodes_to_indices(cg, cond_vars)
   }
 
-  # Check each conditioning set
-
-  for (subset in subsets) {
-    conditioning_set <- c(cond_vars, subset)
-    if (length(conditioning_set) == 0L) {
-      conditioning_set <- NULL
-    }
-
-    if (m_separated(cg, X = node_a, Y = node_b, Z = conditioning_set)) {
-      # Found a set that m-separates them: no edge needed
-      return(FALSE)
-    }
-  }
-
-  # Not m-separated for any conditioning set: edge is required
-
-  TRUE
+  rs_not_m_separated_for_all_subsets(
+    cg@session,
+    node_idx[[1]],
+    node_idx[[2]],
+    other_idx,
+    cond_idx
+  )
 }
 
 #' @title

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1899,6 +1899,79 @@ fn rs_m_separated(
 }
 
 #[extendr]
+fn rs_not_m_separated_for_all_subsets(
+    mut session: ExternalPtr<GraphSession>,
+    node_a: i32,
+    node_b: i32,
+    other_nodes: Integers,
+    cond_vars: Integers,
+) -> bool {
+    let a = rint_to_u32(Rint::from(node_a), "node_a");
+    let b = rint_to_u32(Rint::from(node_b), "node_b");
+
+    if a >= session.as_ref().n() {
+        throw_r_error(format!("Index {} is out of bounds", a));
+    }
+    if b >= session.as_ref().n() {
+        throw_r_error(format!("Index {} is out of bounds", b));
+    }
+
+    let mut z_base: Vec<u32> = cond_vars
+        .iter()
+        .map(|ri| rint_to_u32(ri, "cond_vars"))
+        .collect();
+    let other_u: Vec<u32> = other_nodes
+        .iter()
+        .map(|ri| rint_to_u32(ri, "other_nodes"))
+        .collect();
+
+    for &i in &z_base {
+        if i >= session.as_ref().n() {
+            throw_r_error(format!("Index {} is out of bounds", i));
+        }
+    }
+    for &i in &other_u {
+        if i >= session.as_ref().n() {
+            throw_r_error(format!("Index {} is out of bounds", i));
+        }
+    }
+
+    let m = other_u.len();
+
+    for k in (0..=m).rev() {
+        let mut idx: Vec<usize> = (0..k).collect();
+        loop {
+            z_base.truncate(cond_vars.len());
+            for &ii in &idx {
+                z_base.push(other_u[ii]);
+            }
+
+            if session
+                .as_mut()
+                .m_separated(&[a], &[b], &z_base)
+                .unwrap_or_else(|e| throw_r_error(e))
+            {
+                return false;
+            }
+
+            let mut i = k;
+            while i > 0 && idx[i - 1] == i - 1 + (m - k) {
+                i -= 1;
+            }
+            if i == 0 {
+                break;
+            }
+            idx[i - 1] += 1;
+            for j in i..k {
+                idx[j] = idx[j - 1] + 1;
+            }
+        }
+    }
+
+    true
+}
+
+#[extendr]
 fn rs_adjustment_set_parents(
     mut session: ExternalPtr<GraphSession>,
     xs: Integers,
@@ -2086,6 +2159,7 @@ extendr_module! {
     fn rs_d_separated;
     fn rs_minimal_d_separator;
     fn rs_m_separated;
+    fn rs_not_m_separated_for_all_subsets;
     fn rs_adjustment_set_parents;
     fn rs_adjustment_set_backdoor;
     fn rs_adjustment_set_optimal;

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -970,15 +970,24 @@ test_that("condition_marginalize and helper branches are covered", {
     "must be the same length"
   )
 
-  expect_type(
+  expect_true(
     caugi:::.not_m_separated_for_all_subsets(
       cg = cg2,
       node_a = "A",
       node_b = "C",
       other_nodes = character(0),
       cond_vars = character(0)
-    ),
-    "logical"
+    )
+  )
+
+  expect_false(
+    caugi:::.not_m_separated_for_all_subsets(
+      cg = cg2,
+      node_a = "A",
+      node_b = "C",
+      other_nodes = "B",
+      cond_vars = character(0)
+    )
   )
 
   edge_rev <- caugi:::.edge_type_from_anteriors(
@@ -990,4 +999,139 @@ test_that("condition_marginalize and helper branches are covered", {
   expect_identical(edge_rev$from, "B")
   expect_identical(edge_rev$edge, "-->")
   expect_identical(edge_rev$to, "A")
+})
+
+test_that("not_m_separated helper matches R reference across subset scenarios", {
+  helper_reference <- function(cg, node_a, node_b, other_nodes, cond_vars) {
+    n_other <- length(other_nodes)
+    subsets <- if (n_other == 0L) {
+      list(NULL)
+    } else {
+      c(
+        list(other_nodes),
+        if (n_other > 1L) {
+          unlist(
+            lapply(
+              seq_len(n_other - 1L),
+              function(k) combn(other_nodes, n_other - k, simplify = FALSE)
+            ),
+            recursive = FALSE
+          )
+        },
+        list(NULL)
+      )
+    }
+
+    for (subset in subsets) {
+      z <- c(cond_vars, subset)
+      if (length(z) == 0L) {
+        z <- NULL
+      }
+      if (m_separated(cg, X = node_a, Y = node_b, Z = z)) {
+        return(FALSE)
+      }
+    }
+    TRUE
+  }
+
+  # 1) Separation found only for full subset.
+  # A <- B -> C and A <- D -> C: both B and D are required to block all paths.
+  g_full <- caugi(B %-->% A + C, D %-->% A + C, class = "DAG")
+  expect_true(m_separated(g_full, X = "A", Y = "C", Z = c("B", "D")))
+  expect_false(m_separated(g_full, X = "A", Y = "C", Z = "B"))
+  expect_false(m_separated(g_full, X = "A", Y = "C", Z = "D"))
+
+  rust_full <- caugi:::.not_m_separated_for_all_subsets(
+    g_full,
+    node_a = "A",
+    node_b = "C",
+    other_nodes = c("B", "D"),
+    cond_vars = character(0)
+  )
+  ref_full <- helper_reference(
+    g_full,
+    node_a = "A",
+    node_b = "C",
+    other_nodes = c("B", "D"),
+    cond_vars = character(0)
+  )
+  expect_identical(rust_full, ref_full)
+
+  # 2) Separation found only for an intermediate subset size.
+  # A <- B -> C is blocked by conditioning on B, but conditioning on D opens A->E<-C via E->D.
+  g_mid <- caugi(B %-->% A + C, A %-->% E, C %-->% E, E %-->% D, class = "DAG")
+  expect_true(m_separated(g_mid, X = "A", Y = "C", Z = "B"))
+  expect_false(m_separated(g_mid, X = "A", Y = "C", Z = c("B", "D")))
+
+  rust_mid <- caugi:::.not_m_separated_for_all_subsets(
+    g_mid,
+    node_a = "A",
+    node_b = "C",
+    other_nodes = c("B", "D"),
+    cond_vars = character(0)
+  )
+  ref_mid <- helper_reference(
+    g_mid,
+    node_a = "A",
+    node_b = "C",
+    other_nodes = c("B", "D"),
+    cond_vars = character(0)
+  )
+  expect_identical(rust_mid, ref_mid)
+
+  # 3) Separation found for cond_vars alone.
+  g_cond <- caugi(S %-->% A + C, T %-->% A, class = "DAG")
+  expect_true(m_separated(g_cond, X = "A", Y = "C", Z = "S"))
+
+  rust_cond <- caugi:::.not_m_separated_for_all_subsets(
+    g_cond,
+    node_a = "A",
+    node_b = "C",
+    other_nodes = "T",
+    cond_vars = "S"
+  )
+  ref_cond <- helper_reference(
+    g_cond,
+    node_a = "A",
+    node_b = "C",
+    other_nodes = "T",
+    cond_vars = "S"
+  )
+  expect_identical(rust_cond, ref_cond)
+
+  # Additional parity checks on small random DAGs (all subsets feasible).
+  set.seed(123)
+  for (i in seq_len(20L)) {
+    g <- generate_graph(n = 8, m = 8, class = "DAG")
+    nn <- nodes(g)$name
+    pair <- sample(nn, size = 2, replace = FALSE)
+    rest <- setdiff(nn, pair)
+    other <- sample(rest, size = sample.int(3L, 1), replace = FALSE)
+    cond_pool <- setdiff(rest, other)
+    cond <- if (length(cond_pool) > 0L) {
+      sample(
+        cond_pool,
+        size = sample.int(min(2L, length(cond_pool)), 1) - 1L,
+        replace = FALSE
+      )
+    } else {
+      character(0)
+    }
+
+    rust <- caugi:::.not_m_separated_for_all_subsets(
+      g,
+      node_a = pair[[1]],
+      node_b = pair[[2]],
+      other_nodes = other,
+      cond_vars = cond
+    )
+    ref <- helper_reference(
+      g,
+      node_a = pair[[1]],
+      node_b = pair[[2]],
+      other_nodes = other,
+      cond_vars = cond
+    )
+    expect_identical(rust, ref)
+  }
 })


### PR DESCRIPTION
Rewrite the internal `.not_m_separated_for_all_subsets()` function in Rust instead, to speed it up. The gains depend a bit on sizes and sometimes the runtime is dominated by `m_separarated()`, in which case this gives no measurable benefit.

``` r
library(caugi)

not_m_separated_reference_r <- function(
  cg,
  node_a,
  node_b,
  other_nodes,
  cond_vars
) {
  n_other <- length(other_nodes)

  subsets <- if (n_other == 0L) {
    list(NULL)
  } else {
    c(
      list(other_nodes),
      if (n_other > 1L) {
        unlist(
          lapply(
            seq_len(n_other - 1L),
            function(k) combn(other_nodes, n_other - k, simplify = FALSE)
          ),
          recursive = FALSE
        )
      },
      list(NULL)
    )
  }

  for (subset in subsets) {
    conditioning_set <- c(cond_vars, subset)
    if (length(conditioning_set) == 0L) {
      conditioning_set <- NULL
    }

    if (caugi::m_separated(cg, X = node_a, Y = node_b, Z = conditioning_set)) {
      return(FALSE)
    }
  }

  TRUE
}

make_worst_case_graph <- function(n) {
  if (n < 3L) {
    stop("`n` must be >= 3.", call. = FALSE)
  }
  node_names <- c("A", "B", paste0("X", seq_len(n - 2L)))
  caugi::caugi(
    from = "A",
    edge = "-->",
    to = "B",
    nodes = node_names,
    class = "DAG"
  )
}

benchmark_not_m_separated <- function(
  scenario = c("random", "worst_case"),
  n = c(50, 200),
  p = c(0.5, 0.9),
  other_size = 8L,
  cond_size = 0L,
  max_subsets = 4096L
) {
  scenario <- match.arg(scenario, several.ok = TRUE)
  if (
    !is.numeric(max_subsets) || length(max_subsets) != 1L || max_subsets < 1
  ) {
    stop("`max_subsets` must be a positive scalar.", call. = FALSE)
  }
  max_k <- floor(log2(max_subsets))
  max_k <- max(0L, as.integer(max_k))

  bench::press(
    scenario = scenario,
    n = n,
    p = p,
    other_size = other_size,
    {
      if (scenario == "worst_case") {
        cg <- make_worst_case_graph(n)
        all_nodes <- caugi::nodes(cg)$name
        node_a <- "A"
        node_b <- "B"
        remaining <- setdiff(all_nodes, c(node_a, node_b))
        k_other <- min(other_size, length(remaining))
        k_other <- min(k_other, max_k)
        other_nodes <- remaining[seq_len(k_other)]
        cond_vars <- character(0)
      } else {
        p_mod <- 10 * log10(n) / n * p
        cg <- caugi::generate_graph(n = n, p = p_mod, class = "DAG")
        all_nodes <- caugi::nodes(cg)$name
        pair <- sample(all_nodes, size = 2, replace = FALSE)
        node_a <- pair[[1]]
        node_b <- pair[[2]]
        remaining <- setdiff(all_nodes, c(node_a, node_b))
        k_other <- min(other_size, length(remaining))
        k_other <- min(k_other, max_k)
        other_nodes <- sample(remaining, size = k_other, replace = FALSE)

        remaining_for_cond <- setdiff(remaining, other_nodes)
        k_cond <- min(cond_size, length(remaining_for_cond))
        cond_vars <- if (k_cond > 0L) {
          sample(remaining_for_cond, size = k_cond, replace = FALSE)
        } else {
          character(0)
        }
      }

      bench::mark(
        rust = caugi:::.not_m_separated_for_all_subsets(
          cg = cg,
          node_a = node_a,
          node_b = node_b,
          other_nodes = other_nodes,
          cond_vars = cond_vars
        ),
        reference_r = not_m_separated_reference_r(
          cg = cg,
          node_a = node_a,
          node_b = node_b,
          other_nodes = other_nodes,
          cond_vars = cond_vars
        )
      )
    }
  )
}

benchmark_not_m_separated() |> plot()
#> Running with:
#>   scenario       n     p other_size
#> 1 random        50   0.5          8
#> 2 worst_case    50   0.5          8
#> 3 random       200   0.5          8
#> 4 worst_case   200   0.5          8
#> 5 random        50   0.9          8
#> 6 worst_case    50   0.9          8
#> 7 random       200   0.9          8
#> 8 worst_case   200   0.9          8
```

![](https://i.imgur.com/9YnKsm6.png)<!-- -->

<sup>Created on 2026-04-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>