### PR TITLE
Add NetworkX tests

### DIFF
--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -108,6 +108,36 @@ test_that("moralize fails on non-DAGs", {
   )
 })
 
+############# NetworkX tests for moralization #############
+# https://github.com/networkx/networkx/blob/main/networkx/algorithms/tests/test_moral.py
+
+test_that("NetworkX moralize test 1", {
+  cg <- caugi(
+    A %-->% B,
+    C %-->% B,
+    D %-->% A,
+    D %-->% E,
+    F %-->% E,
+    G %-->% E,
+    class = "DAG"
+  )
+  moral_cg <- moralize(cg)
+  expect_equal(moral_cg@graph_class, "UG")
+
+  has_edge <- function(edges, u, v) {
+    any(
+      (edges$from == u & edges$to == v) |
+        (edges$from == v & edges$to == u)
+    )
+  }
+
+  expect_true(has_edge(moral_cg@edges, "A", "C"))
+  expect_true(has_edge(moral_cg@edges, "D", "F"))
+  expect_true(has_edge(moral_cg@edges, "F", "G"))
+  expect_true(has_edge(moral_cg@edges, "D", "G"))
+  expect_false(has_edge(moral_cg@edges, "A", "E"))
+})
+
 # ──────────────────────────────────────────────────────────────────────────────
 # ───────────────────────────────── Mutation ───────────────────────────────────
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -1623,3 +1623,71 @@ test_that("nodes_to_indices errors when session is missing", {
     "Cannot look up indices for empty graph."
   )
 })
+
+
+################# NetworkX tests ##############
+# topological sort tests:
+# https://github.com/networkx/networkx/blob/main/networkx/algorithms/tests/test_dag.py
+# All the other ones are just raising errors, etc, and thus only the below are ported.
+
+test_that("topological sort NetworkX 1 test", {
+  cg <- caugi(A %-->% B + C, B %-->% C, class = "DAG")
+  ts_cg <- topological_sort(cg)
+  expect_equal(ts_cg, c("A", "B", "C"))
+
+  cg <- caugi(A %-->% B + C, C %-->% B, class = "DAG")
+  ts_cg <- topological_sort(cg)
+  expect_equal(ts_cg, c("A", "C", "B"))
+})
+
+test_that("topological sort NetworkX 2 test", {
+  cg <- caugi(A %-->% B, B %-->% C, C %-->% D, D %-->% E, class = "DAG")
+  ts_cg <- topological_sort(cg)
+  expect_equal(ts_cg, c("A", "B", "C", "D", "E"))
+
+  cg <- caugi(A %-->% B + C, C %-->% B, class = "DAG")
+  ts_cg <- topological_sort(cg)
+  expect_equal(ts_cg, c("A", "C", "B"))
+})
+
+
+# ancestors and descendants tests:
+# https://github.com/networkx/networkx/blob/main/networkx/algorithms/tests/test_dag.py
+
+test_that("ancestors NetworkX 1 test", {
+  cg <- caugi(
+    A %-->% B + C,
+    D %-->% B + E,
+    D %-->% C,
+    B %-->% F,
+    E %-->% F,
+    class = "DAG"
+  )
+  ancestors_cg_f <- ancestors(cg, nodes = "F")
+  expect_setequal(ancestors_cg_f, c("A", "B", "D", "E"))
+
+  ancestors_cg_c <- ancestors(cg, nodes = "C")
+  expect_setequal(ancestors_cg_c, c("A", "D"))
+
+  ancestors_cg_a <- ancestors(cg, nodes = "A")
+  expect_null(ancestors_cg_a)
+})
+
+test_that("descendants NetworkX 1 test", {
+  cg <- caugi(
+    A %-->% B + C,
+    D %-->% B + E,
+    D %-->% C,
+    B %-->% F,
+    E %-->% F,
+    class = "DAG"
+  )
+  descendants_cg_a <- descendants(cg, nodes = "A")
+  expect_setequal(descendants_cg_a, c("B", "C", "F"))
+
+  descendants_cg_d <- descendants(cg, nodes = "D")
+  expect_setequal(descendants_cg_d, c("B", "C", "E", "F"))
+
+  descendants_cg_c <- descendants(cg, nodes = "C")
+  expect_null(descendants_cg_c)
+})


### PR DESCRIPTION
Adds the relevant tests from #225 in [Various DAG things](https://github.com/networkx/networkx/blob/main/networkx/algorithms/tests/test_dag.py) and in [Moralize](https://github.com/networkx/networkx/blob/main/networkx/algorithms/tests/test_moral.py).

Didn't add the chordal and clique, since only in Rust. But IMO, we can close the issue now.