### PR TITLE
chore: use more general AGENTS.md, and add CLAUDE.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -39,3 +39,5 @@
 ^devenv\.nix$
 ^devenv\.yaml$
 ^\.pre-commit-config\.yaml$
+^AGENTS\.md$
+^CLAUDE\.md$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for caugi
+# Agent Instructions for caugi
 
 ## Repository Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
I think we should switch to the more general `AGENTS.md` file instead of the copilot-specific one, which is more accessible. Even Copilot accepts AGENTS.md. I also added a CLAUDE.md file that just points to the AGENTS.md file.