### PR TITLE
Update classes in as_caugi()

### DIFF
--- a/R/as_caugi.R
+++ b/R/as_caugi.R
@@ -14,9 +14,9 @@
 #' - 3: tail (e.g., `A o-- B` or `A --- B`)
 #'
 #' @param x An object to convert to a `caugi`.
-#' @param class "DAG", "PDAG", "MPDAG", "ADMG", "PAG", or "UNKNOWN".
-#' "PAG" is only supported for integer coded matrices.
-#' "ADMG" is for Acyclic Directed Mixed Graphs (with `-->` and `<->` edges).
+#' @param class Character; one of `"DAG"`, `"UG"`, `"PDAG"`, `"MPDAG"`,
+#'  `"ADMG"`, `"AG"`, or `"UNKNOWN"`. `"PAG"` is only supported for integer
+#'  coded matrices.
 #' @param simple logical. If `TRUE` (default) the graph will be simple
 #' (no multiple edges or self-loops).
 #' @param collapse logical. If `TRUE` collapse mutual directed edges to
@@ -98,7 +98,7 @@ as_caugi <- S7::new_generic(
   dispatch_args = "x",
   fun = function(
     x,
-    class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+    class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
     simple = TRUE,
     collapse = FALSE,
     collapse_to = "---",
@@ -113,7 +113,7 @@ S7::method(
   S7::new_S3_class("igraph")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -198,7 +198,7 @@ register_graphnel_s4_class <- function() {
     methods::getClassDef("graphNEL", package = "graph")
   ) <- function(
     x,
-    class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+    class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
     simple = TRUE,
     collapse = FALSE,
     collapse_to = "---",
@@ -274,7 +274,7 @@ S7::method(
   S7::new_S3_class("integer")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -464,7 +464,7 @@ S7::method(
   S7::new_S3_class("double")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -497,7 +497,7 @@ S7::method(
   S7::new_S3_class("logical")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -527,7 +527,7 @@ register_matrix_s4_class <- function() {
     methods::getClassDef("Matrix", package = "Matrix")
   ) <- function(
     x,
-    class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+    class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
     simple = TRUE,
     collapse = FALSE,
     collapse_to = "---",
@@ -551,7 +551,7 @@ S7::method(
   S7::new_S3_class("tidygraph")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -576,7 +576,7 @@ S7::method(
   S7::new_S3_class("dagitty")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -684,7 +684,7 @@ S7::method(
   S7::new_S3_class("bn")
 ) <- function(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",

--- a/man/as_caugi.Rd
+++ b/man/as_caugi.Rd
@@ -6,7 +6,7 @@
 \usage{
 as_caugi(
   x,
-  class = c("DAG", "PDAG", "MPDAG", "ADMG", "PAG", "UNKNOWN"),
+  class = c("DAG", "UG", "PDAG", "MPDAG", "ADMG", "AG", "PAG", "UNKNOWN"),
   simple = TRUE,
   collapse = FALSE,
   collapse_to = "---",
@@ -16,9 +16,9 @@ as_caugi(
 \arguments{
 \item{x}{An object to convert to a \code{caugi}.}
 
-\item{class}{"DAG", "PDAG", "MPDAG", "ADMG", "PAG", or "UNKNOWN".
-"PAG" is only supported for integer coded matrices.
-"ADMG" is for Acyclic Directed Mixed Graphs (with \verb{-->} and \verb{<->} edges).}
+\item{class}{Character; one of \code{"DAG"}, \code{"UG"}, \code{"PDAG"}, \code{"MPDAG"},
+\code{"ADMG"}, \code{"AG"}, or \code{"UNKNOWN"}. \code{"PAG"} is only supported for integer
+coded matrices.}
 
 \item{simple}{logical. If \code{TRUE} (default) the graph will be simple
 (no multiple edges or self-loops).}
@@ -114,10 +114,10 @@ cg <- as_caugi(M, class = "PAG")
 
 }
 \seealso{
-Other conversions: 
-\code{\link{as_adjacency}()},
-\code{\link{as_bnlearn}()},
-\code{\link{as_dagitty}()},
-\code{\link{as_igraph}()}
+Other conversions:
+\code{\link[=as_adjacency]{as_adjacency()}},
+\code{\link[=as_bnlearn]{as_bnlearn()}},
+\code{\link[=as_dagitty]{as_dagitty()}},
+\code{\link[=as_igraph]{as_igraph()}}
 }
 \concept{conversions}


### PR DESCRIPTION
I saw `as_caugi()` still used old classes, and wasn't updated to also have AG and UG.