### PR TITLE
feat: promote graph type to `MPDAG` when generating `CPDAG`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # caugi (development version)
 
+## Improvements
+
+- Meek-closed PDAGs are now reported with `@graph_class = "MPDAG"` instead of
+  `"PDAG"`. This affects the result of `meek_closure()` and
+  `generate_graph(class = "CPDAG")`. Predicates and verbs defined on PDAGs
+  (`is_pdag()`, `mutate_caugi()`, etc.) continue to accept MPDAGs unchanged.
+
 # caugi 1.2.0
 
 ## New Features

--- a/R/operations.R
+++ b/R/operations.R
@@ -71,8 +71,8 @@ skeleton <- function(cg) {
 #'
 #' @param cg A `caugi` object. Must be PDAG-compatible.
 #'
-#' @returns A `caugi` object of class `"PDAG"` that is closed under Meek's
-#'   rules.
+#' @returns A `caugi` object closed under Meek's rules. Class `"MPDAG"` in
+#'   general, or `"DAG"` if the closure orients every edge.
 #'
 #' @references
 #' C. Meek (1995). Causal inference and causal explanation with background

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -8,17 +8,21 @@
 #' of `m` or `p` must be supplied.
 #' @param p Numeric in `[0,1]`. Probability of edge creation. Exactly one of
 #' `m` or `p` must be supplied.
-#' @param class "DAG" or "CPDAG".
+#' @param class "DAG" or "CPDAG". When `"CPDAG"`, the result is the Meek
+#'   closure of the sampled DAG and is returned with class `"MPDAG"`; a true
+#'   CPDAG type is not yet implemented.
 #' @param seed Optional integer; random seed for reproducibility.
 #'
-#' @returns The sampled `caugi` object.
+#' @returns The sampled `caugi` object. `class = "DAG"` returns a `"DAG"`;
+#'   `class = "CPDAG"` returns an `"MPDAG"`.
 #'
 #' @examples
 #' # generate a random DAG with 5 nodes and 4 edges
 #' dag <- generate_graph(n = 5, m = 4, class = "DAG")
 #'
 #' # generate a random CPDAG with 5 nodes and edge probability 0.3
-#' cpdag <- generate_graph(n = 5, p = 0.3, class = "CPDAG")
+#' # (returned as an MPDAG; see Details)
+#' mpdag <- generate_graph(n = 5, p = 0.3, class = "CPDAG")
 #'
 #' @family simulation functions
 #' @concept simulation

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -21,7 +21,7 @@
 #' dag <- generate_graph(n = 5, m = 4, class = "DAG")
 #'
 #' # generate a random CPDAG with 5 nodes and edge probability 0.3
-#' # (returned as an MPDAG; see Details)
+#' # (returned as an MPDAG)
 #' mpdag <- generate_graph(n = 5, p = 0.3, class = "CPDAG")
 #'
 #' @family simulation functions

--- a/man/as_caugi.Rd
+++ b/man/as_caugi.Rd
@@ -114,10 +114,10 @@ cg <- as_caugi(M, class = "PAG")
 
 }
 \seealso{
-Other conversions:
-\code{\link[=as_adjacency]{as_adjacency()}},
-\code{\link[=as_bnlearn]{as_bnlearn()}},
-\code{\link[=as_dagitty]{as_dagitty()}},
-\code{\link[=as_igraph]{as_igraph()}}
+Other conversions: 
+\code{\link{as_adjacency}()},
+\code{\link{as_bnlearn}()},
+\code{\link{as_dagitty}()},
+\code{\link{as_igraph}()}
 }
 \concept{conversions}

--- a/man/generate_graph.Rd
+++ b/man/generate_graph.Rd
@@ -34,7 +34,7 @@ Erdős-Rényi for random graph generation.
 dag <- generate_graph(n = 5, m = 4, class = "DAG")
 
 # generate a random CPDAG with 5 nodes and edge probability 0.3
-# (returned as an MPDAG; see Details)
+# (returned as an MPDAG)
 mpdag <- generate_graph(n = 5, p = 0.3, class = "CPDAG")
 
 }

--- a/man/generate_graph.Rd
+++ b/man/generate_graph.Rd
@@ -15,12 +15,15 @@ of \code{m} or \code{p} must be supplied.}
 \item{p}{Numeric in \verb{[0,1]}. Probability of edge creation. Exactly one of
 \code{m} or \code{p} must be supplied.}
 
-\item{class}{"DAG" or "CPDAG".}
+\item{class}{"DAG" or "CPDAG". When \code{"CPDAG"}, the result is the Meek
+closure of the sampled DAG and is returned with class \code{"MPDAG"}; a true
+CPDAG type is not yet implemented.}
 
 \item{seed}{Optional integer; random seed for reproducibility.}
 }
 \value{
-The sampled \code{caugi} object.
+The sampled \code{caugi} object. \code{class = "DAG"} returns a \code{"DAG"};
+\code{class = "CPDAG"} returns an \code{"MPDAG"}.
 }
 \description{
 Sample a random DAG or CPDAG using
@@ -31,7 +34,8 @@ Erdős-Rényi for random graph generation.
 dag <- generate_graph(n = 5, m = 4, class = "DAG")
 
 # generate a random CPDAG with 5 nodes and edge probability 0.3
-cpdag <- generate_graph(n = 5, p = 0.3, class = "CPDAG")
+# (returned as an MPDAG; see Details)
+mpdag <- generate_graph(n = 5, p = 0.3, class = "CPDAG")
 
 }
 \seealso{

--- a/man/meek_closure.Rd
+++ b/man/meek_closure.Rd
@@ -10,8 +10,8 @@ meek_closure(cg)
 \item{cg}{A \code{caugi} object. Must be PDAG-compatible.}
 }
 \value{
-A \code{caugi} object of class \code{"PDAG"} that is closed under Meek's
-rules.
+A \code{caugi} object closed under Meek's rules. Class \code{"MPDAG"} in
+general, or \code{"DAG"} if the closure orients every edge.
 }
 \description{
 Applies Meek's orientation rules (R1--R4) repeatedly to a PDAG until no more

--- a/src/rust/src/graph/dag/transforms.rs
+++ b/src/rust/src/graph/dag/transforms.rs
@@ -5,6 +5,7 @@ use super::Dag;
 use crate::edges::EdgeClass;
 use crate::graph::admg::Admg;
 use crate::graph::alg::{csr, meek};
+use crate::graph::mpdag::Mpdag;
 use crate::graph::pdag::Pdag;
 use crate::graph::ug::Ug;
 use crate::graph::CaugiGraph;
@@ -657,7 +658,7 @@ impl Dag {
     /// C. Meek (1995). Causal inference and causal explanation with background
     /// knowledge. In *Proceedings of the Eleventh Conference on Uncertainty in
     /// Artificial Intelligence (UAI-95)*, pp. 403–411. Morgan Kaufmann.
-    pub fn to_cpdag(&self) -> Result<Pdag, String> {
+    pub fn to_cpdag(&self) -> Result<Mpdag, String> {
         let n = self.n() as usize;
 
         let mut pa: Vec<HashSet<u32>> = vec![HashSet::new(); n];
@@ -764,7 +765,8 @@ impl Dag {
             /*simple=*/ true,
             self.core_ref().registry.clone(),
         )?;
-        Pdag::new(Arc::new(core))
+        let pdag = Pdag::new(Arc::new(core))?;
+        Ok(Mpdag::from_closed_unchecked(pdag))
     }
 }
 

--- a/src/rust/src/graph/pdag/transforms.rs
+++ b/src/rust/src/graph/pdag/transforms.rs
@@ -4,6 +4,7 @@
 use super::Pdag;
 use crate::edges::EdgeClass;
 use crate::graph::alg::{csr, meek};
+use crate::graph::mpdag::Mpdag;
 use crate::graph::ug::Ug;
 use crate::graph::CaugiGraph;
 use std::collections::HashSet;
@@ -24,8 +25,13 @@ impl Pdag {
         Ug::new(Arc::new(core))
     }
 
-    /// Apply Meek closure on a PDAG and return the resulting CPDAG.
-    pub fn to_cpdag(&self) -> Result<Pdag, String> {
+    /// Apply Meek closure on a PDAG and return the resulting MPDAG.
+    ///
+    /// This is *not* `Pdag → Cpdag`: closure only orients edges that Meek's
+    /// rules force, so the result may include non-compelled (background-
+    /// knowledge) orientations and need not have chordal chain components.
+    /// For a true CPDAG, start from a `Dag` and call `Dag::to_cpdag`.
+    pub fn to_mpdag(&self) -> Result<Mpdag, String> {
         let n = self.n() as usize;
 
         let mut pa: Vec<HashSet<u32>> = vec![HashSet::new(); n];
@@ -116,12 +122,13 @@ impl Pdag {
             /*simple=*/ true,
             self.core_ref().registry.clone(),
         )?;
-        Pdag::new(Arc::new(core))
+        let pdag = Pdag::new(Arc::new(core))?;
+        Ok(Mpdag::from_closed_unchecked(pdag))
     }
 
     /// Orient all compelled edges implied by Meek rules (R1..R4).
-    pub fn meek_closure(&self) -> Result<Pdag, String> {
-        self.to_cpdag()
+    pub fn meek_closure(&self) -> Result<Mpdag, String> {
+        self.to_mpdag()
     }
 }
 

--- a/src/rust/src/graph/session.rs
+++ b/src/rust/src/graph/session.rs
@@ -10,6 +10,7 @@ use super::admg::Admg;
 use super::ag::Ag;
 use super::builder::GraphBuilder;
 use super::dag::Dag;
+use super::mpdag::Mpdag;
 use super::pdag::Pdag;
 use super::ug::Ug;
 use super::view::GraphView;
@@ -489,11 +490,8 @@ impl GraphSession {
             }
             GraphClass::Mpdag => {
                 let pdag = Pdag::new(core).map_err(|e| self.map_error(e))?;
-                if pdag.is_meek_closed() {
-                    Ok(GraphView::Pdag(Arc::new(pdag)))
-                } else {
-                    Err("graph is not MPDAG (not closed under Meek rules)".to_string())
-                }
+                let mpdag = Mpdag::try_new(pdag).map_err(|e| self.map_error(e))?;
+                Ok(GraphView::Mpdag(Arc::new(mpdag)))
             }
             GraphClass::Ug => {
                 let ug = Ug::new(core).map_err(|e| self.map_error(e))?;
@@ -683,7 +681,7 @@ impl GraphSession {
     pub fn is_mpdag(&mut self) -> Result<bool, String> {
         let core = self.core()?;
         match Pdag::new(Arc::new(core.as_ref().clone())) {
-            Ok(p) => Ok(p.is_meek_closed()),
+            Ok(p) => Ok(Mpdag::try_new(p).is_ok()),
             Err(_) => Ok(false),
         }
     }
@@ -712,11 +710,8 @@ impl GraphSession {
             GraphClass::Mpdag => {
                 let pdag =
                     Pdag::new(Arc::new(core.as_ref().clone())).map_err(|e| self.map_error(e))?;
-                if pdag.is_meek_closed() {
-                    Ok(GraphClass::Mpdag)
-                } else {
-                    Err("graph is not MPDAG (not closed under Meek rules)".to_string())
-                }
+                Mpdag::try_new(pdag).map_err(|e| self.map_error(e))?;
+                Ok(GraphClass::Mpdag)
             }
             GraphClass::Ug => {
                 Ug::new(Arc::new(core.as_ref().clone())).map_err(|e| self.map_error(e))?;
@@ -764,7 +759,7 @@ impl GraphSession {
         let core = self.core()?;
         let pdag = Pdag::new(Arc::new(core.as_ref().clone())).map_err(|e| self.map_error(e))?;
         let closed = pdag.meek_closure().map_err(|e| self.map_error(e))?;
-        Ok(GraphView::Pdag(Arc::new(closed)))
+        Ok(GraphView::Mpdag(Arc::new(closed)))
     }
 
     /// Skeleton of the graph.
@@ -1432,7 +1427,7 @@ mod tests {
         );
 
         let to_cpdag = session.to_cpdag().unwrap();
-        assert!(matches!(to_cpdag, GraphView::Pdag(_)));
+        assert!(matches!(to_cpdag, GraphView::Mpdag(_)));
 
         let skeleton = session.skeleton().unwrap();
         assert!(matches!(skeleton, GraphView::Ug(_)));
@@ -1568,7 +1563,7 @@ mod tests {
         mpdag_edges.push(0, 2, d);
         mpdag_edges.push(1, 2, d);
         mpdag.set_edges(mpdag_edges);
-        assert!(matches!(&*mpdag.view().unwrap(), GraphView::Pdag(_)));
+        assert!(matches!(&*mpdag.view().unwrap(), GraphView::Mpdag(_)));
         assert_eq!(
             mpdag.resolve_class(GraphClass::Mpdag).unwrap(),
             GraphClass::Mpdag
@@ -1938,13 +1933,18 @@ mod tests {
         let exo2 = pdag.exogenous_nodes(true).unwrap();
         assert!(exo2.contains(&0));
 
-        // to_cpdag on PDAG applies Meek closure
-        let cpdag = pdag.to_cpdag().unwrap();
-        match cpdag {
-            GraphView::Pdag(cp) => {
+        // to_cpdag is DAG-only; on a PDAG it errors.
+        assert_eq!(
+            pdag.to_cpdag().unwrap_err(),
+            "to_cpdag is only defined for DAGs"
+        );
+        // meek_closure on a PDAG yields an MPDAG.
+        let mpdag = pdag.meek_closure().unwrap();
+        match mpdag {
+            GraphView::Mpdag(cp) => {
                 assert_eq!(cp.children_of(1), &[2]); // 0->1, 1--2 => 1->2
             }
-            _ => panic!("expected PDAG"),
+            _ => panic!("expected MPDAG"),
         }
 
         // Error paths for PDAG

--- a/src/rust/src/graph/view.rs
+++ b/src/rust/src/graph/view.rs
@@ -1,6 +1,7 @@
 use super::admg::Admg;
 use super::ag::Ag;
 use super::dag::Dag;
+use super::mpdag::Mpdag;
 use super::pdag::Pdag;
 use super::ug::Ug;
 use super::CaugiGraph;
@@ -42,6 +43,7 @@ impl NeighborMode {
 pub enum GraphView {
     Dag(Arc<Dag>),
     Pdag(Arc<Pdag>),
+    Mpdag(Arc<Mpdag>),
     Ug(Arc<Ug>),
     Admg(Arc<Admg>),
     Ag(Arc<Ag>),
@@ -54,6 +56,7 @@ impl GraphView {
         match self {
             GraphView::Dag(d) => d.core_ref(),
             GraphView::Pdag(p) => p.core_ref(),
+            GraphView::Mpdag(m) => m.as_pdag().core_ref(),
             GraphView::Ug(u) => u.core_ref(),
             GraphView::Admg(a) => a.core_ref(),
             GraphView::Ag(g) => g.core_ref(),
@@ -66,6 +69,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => g.n(),
             GraphView::Pdag(g) => g.n(),
+            GraphView::Mpdag(g) => g.n(),
             GraphView::Ug(g) => g.n(),
             GraphView::Admg(g) => g.n(),
             GraphView::Ag(g) => g.n(),
@@ -145,6 +149,18 @@ impl GraphView {
             (GraphView::Pdag(g), NeighborMode::In) => Ok(g.parents_of(i).to_vec()),
             (GraphView::Pdag(g), NeighborMode::Out) => Ok(g.children_of(i).to_vec()),
             (GraphView::Pdag(g), NeighborMode::Undirected) => Ok(g.undirected_of(i).to_vec()),
+            (GraphView::Mpdag(m), NeighborMode::All) => Ok(m.as_pdag().neighbors_of(i).to_vec()),
+            (GraphView::Mpdag(m), NeighborMode::In) => Ok(m.as_pdag().parents_of(i).to_vec()),
+            (GraphView::Mpdag(m), NeighborMode::Out) => Ok(m.as_pdag().children_of(i).to_vec()),
+            (GraphView::Mpdag(m), NeighborMode::Undirected) => {
+                Ok(m.as_pdag().undirected_of(i).to_vec())
+            }
+            (GraphView::Mpdag(_), NeighborMode::Bidirected) => {
+                Err("mode 'bidirected' not valid for MPDAG (no bidirected edges)".into())
+            }
+            (GraphView::Mpdag(_), NeighborMode::Partial) => {
+                Err("mode 'partial' not valid for MPDAG (no partial edges)".into())
+            }
             (GraphView::Pdag(_), NeighborMode::Bidirected) => {
                 Err("mode 'bidirected' not valid for PDAG (no bidirected edges)".into())
             }
@@ -260,6 +276,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => Ok(g.ancestors_of(i)),
             GraphView::Pdag(g) => Ok(g.ancestors_of(i)),
+            GraphView::Mpdag(m) => Ok(m.as_pdag().ancestors_of(i)),
             GraphView::Admg(g) => Ok(g.ancestors_of(i)),
             GraphView::Ag(g) => Ok(g.ancestors_of(i)),
             GraphView::Ug(_) => Err("ancestors_of not defined for UG".into()),
@@ -270,6 +287,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => Ok(g.descendants_of(i)),
             GraphView::Pdag(g) => Ok(g.descendants_of(i)),
+            GraphView::Mpdag(m) => Ok(m.as_pdag().descendants_of(i)),
             GraphView::Admg(g) => Ok(g.descendants_of(i)),
             GraphView::Ag(g) => Ok(g.descendants_of(i)),
             GraphView::Ug(_) => Err("descendants_of not defined for UG".into()),
@@ -280,6 +298,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => Ok(g.anteriors_of(i)),
             GraphView::Pdag(g) => Ok(g.anteriors_of(i)),
+            GraphView::Mpdag(m) => Ok(m.as_pdag().anteriors_of(i)),
             GraphView::Admg(_) => Err("anteriors_of not defined for ADMG".into()),
             GraphView::Ag(g) => Ok(g.anteriors_of(i)),
             GraphView::Ug(_) => Err("anteriors_of not defined for UG".into()),
@@ -290,6 +309,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => Ok(g.posteriors_of(i)),
             GraphView::Pdag(g) => Ok(g.posteriors_of(i)),
+            GraphView::Mpdag(m) => Ok(m.as_pdag().posteriors_of(i)),
             GraphView::Admg(_) => Err("posteriors_of not defined for ADMG".into()),
             GraphView::Ag(g) => Ok(g.posteriors_of(i)),
             GraphView::Ug(_) => Err("posteriors_of not defined for UG".into()),
@@ -300,6 +320,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => Ok(g.markov_blanket_of(i)),
             GraphView::Pdag(g) => Ok(g.markov_blanket_of(i)),
+            GraphView::Mpdag(m) => Ok(m.as_pdag().markov_blanket_of(i)),
             GraphView::Ug(g) => Ok(g.markov_blanket_of(i)),
             GraphView::Admg(g) => Ok(g.markov_blanket_of(i)),
             GraphView::Ag(g) => Ok(g.markov_blanket_of(i)),
@@ -310,6 +331,7 @@ impl GraphView {
         match self {
             GraphView::Dag(g) => Ok(g.exogenous_nodes()),
             GraphView::Pdag(g) => Ok(g.exogenous_nodes(undirected_as_parents)),
+            GraphView::Mpdag(m) => Ok(m.as_pdag().exogenous_nodes(undirected_as_parents)),
             GraphView::Ug(g) => Ok(g.exogenous_nodes()),
             GraphView::Admg(g) => Ok(g.exogenous_nodes()),
             GraphView::Ag(g) => {
@@ -334,6 +356,7 @@ impl GraphView {
             GraphView::Dag(g) => Ok(g.topological_sort()),
             GraphView::Admg(_) => Err("topological_sort is only defined for DAGs".into()),
             GraphView::Pdag(_) => Err("topological_sort is only defined for DAGs".into()),
+            GraphView::Mpdag(_) => Err("topological_sort is only defined for DAGs".into()),
             GraphView::Ug(_) => Err("topological_sort is only defined for DAGs".into()),
             GraphView::Ag(_) => Err("topological_sort is only defined for DAGs".into()),
             GraphView::Raw(_) => Err("topological_sort is only defined for DAGs".into()),
@@ -472,6 +495,15 @@ impl GraphView {
                 let p = super::pdag::Pdag::new(std::sync::Arc::new(core2))?;
                 GraphView::Pdag(std::sync::Arc::new(p))
             }
+            GraphView::Mpdag(_) => {
+                let p = super::pdag::Pdag::new(std::sync::Arc::new(core2))?;
+                if p.is_meek_closed() {
+                    let m = super::mpdag::Mpdag::from_closed_unchecked(p);
+                    GraphView::Mpdag(std::sync::Arc::new(m))
+                } else {
+                    GraphView::Pdag(std::sync::Arc::new(p))
+                }
+            }
             GraphView::Ug(_) => {
                 let u = super::ug::Ug::new(std::sync::Arc::new(core2))?;
                 GraphView::Ug(std::sync::Arc::new(u))
@@ -491,17 +523,38 @@ impl GraphView {
 }
 
 impl GraphView {
+    /// Convert to a CPDAG (essential graph of the Markov equivalence class).
+    ///
+    /// Only defined for DAGs. For PDAGs/MPDAGs, a true `to_cpdag` would
+    /// require extending the PDAG to a consistent DAG (Dor-Tarsi) and then
+    /// computing that DAG's CPDAG, which is not yet implemented. Use
+    /// `to_mpdag` instead to apply Meek closure.
     pub fn to_cpdag(&self) -> Result<GraphView, String> {
         match self {
             GraphView::Dag(d) => {
-                let p = d.to_cpdag()?;
-                Ok(GraphView::Pdag(std::sync::Arc::new(p)))
+                let m = d.to_cpdag()?;
+                Ok(GraphView::Mpdag(std::sync::Arc::new(m)))
+            }
+            _ => Err("to_cpdag is only defined for DAGs".into()),
+        }
+    }
+
+    /// Apply Meek closure and return an MPDAG.
+    ///
+    /// Defined for DAGs (delegates to `to_cpdag` since a CPDAG is an MPDAG),
+    /// PDAGs (applies Meek closure), and MPDAGs (identity).
+    pub fn to_mpdag(&self) -> Result<GraphView, String> {
+        match self {
+            GraphView::Dag(d) => {
+                let m = d.to_cpdag()?;
+                Ok(GraphView::Mpdag(std::sync::Arc::new(m)))
             }
             GraphView::Pdag(p) => {
-                let cp = p.to_cpdag()?;
-                Ok(GraphView::Pdag(std::sync::Arc::new(cp)))
+                let m = p.to_mpdag()?;
+                Ok(GraphView::Mpdag(std::sync::Arc::new(m)))
             }
-            _ => Err("to_cpdag is only defined for DAGs and PDAGs".into()),
+            GraphView::Mpdag(m) => Ok(GraphView::Mpdag(std::sync::Arc::clone(m))),
+            _ => Err("to_mpdag is only defined for DAGs, PDAGs, and MPDAGs".into()),
         }
     }
 
@@ -513,6 +566,10 @@ impl GraphView {
             }
             GraphView::Pdag(p) => {
                 let ug = p.skeleton()?;
+                Ok(GraphView::Ug(Arc::new(ug)))
+            }
+            GraphView::Mpdag(m) => {
+                let ug = m.as_pdag().skeleton()?;
                 Ok(GraphView::Ug(Arc::new(ug)))
             }
             _ => Err("skeleton is defined for DAGs and PDAGs only".into()),
@@ -614,6 +671,13 @@ impl GraphView {
             }
             GraphView::Pdag(p) => {
                 use crate::graph::alg::bitset;
+                let mask = bitset::ancestors_mask(seeds, |u| p.parents_of(u), p.n());
+                let keep = bitset::collect_from_mask(&mask);
+                self.induced_subgraph(&keep)
+            }
+            GraphView::Mpdag(m) => {
+                use crate::graph::alg::bitset;
+                let p = m.as_pdag();
                 let mask = bitset::ancestors_mask(seeds, |u| p.parents_of(u), p.n());
                 let keep = bitset::collect_from_mask(&mask);
                 self.induced_subgraph(&keep)
@@ -1111,9 +1175,14 @@ mod tests {
             "all_adjustment_sets_admg is only defined for ADMGs"
         );
 
-        // Pdag -> CPDAG passthrough branch
-        let cp = v_pdag.to_cpdag().unwrap();
-        assert!(matches!(cp, GraphView::Pdag(_)));
+        // Pdag -> MPDAG via meek closure
+        let cp = v_pdag.to_mpdag().unwrap();
+        assert!(matches!(cp, GraphView::Mpdag(_)));
+        // to_cpdag is DAG-only
+        assert_eq!(
+            v_pdag.to_cpdag().unwrap_err(),
+            "to_cpdag is only defined for DAGs"
+        );
 
         // DAG-only transform helpers error branches on non-DAG
         assert_eq!(

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -14,7 +14,7 @@ use graph::metrics::aid;
 use graph::metrics::{hd, shd_with_perm};
 
 use graph::view::GraphView;
-use graph::{admg::Admg, ag::Ag, dag::Dag, pdag::Pdag, ug::Ug, CaugiGraph};
+use graph::{admg::Admg, ag::Ag, dag::Dag, mpdag::Mpdag, pdag::Pdag, ug::Ug, CaugiGraph};
 use std::sync::Arc;
 
 // ---------- helpers ----------
@@ -359,6 +359,7 @@ fn graph_class_from_view(view: &GraphView) -> GraphClass {
     match view {
         GraphView::Dag(_) => GraphClass::Dag,
         GraphView::Pdag(_) => GraphClass::Pdag,
+        GraphView::Mpdag(_) => GraphClass::Mpdag,
         GraphView::Ug(_) => GraphClass::Ug,
         GraphView::Admg(_) => GraphClass::Admg,
         GraphView::Ag(_) => GraphClass::Ag,
@@ -370,6 +371,7 @@ fn graph_class_label_from_view(view: &GraphView) -> &'static str {
     match view {
         GraphView::Dag(_) => "DAG",
         GraphView::Pdag(_) => "PDAG",
+        GraphView::Mpdag(_) => "MPDAG",
         GraphView::Ug(_) => "UG",
         GraphView::Admg(_) => "ADMG",
         GraphView::Ag(_) => "AG",
@@ -554,12 +556,14 @@ fn graphview_new(core: ExternalPtr<CaugiGraph>, class: &str) -> ExternalPtr<Grap
             let dag = Dag::new(Arc::clone(&core_arc)).unwrap_or_else(|e| throw_r_error(e));
             ExternalPtr::new(GraphView::Dag(Arc::new(dag)))
         }
-        "PDAG" | "CPDAG" | "MPDAG" => {
+        "PDAG" => {
             let pdag = Pdag::new(Arc::clone(&core_arc)).unwrap_or_else(|e| throw_r_error(e));
-            if class.trim().eq_ignore_ascii_case("MPDAG") && !pdag.is_meek_closed() {
-                throw_r_error("graph is not MPDAG (not closed under Meek rules)");
-            }
             ExternalPtr::new(GraphView::Pdag(Arc::new(pdag)))
+        }
+        "CPDAG" | "MPDAG" => {
+            let pdag = Pdag::new(Arc::clone(&core_arc)).unwrap_or_else(|e| throw_r_error(e));
+            let mpdag = Mpdag::try_new(pdag).unwrap_or_else(|e| throw_r_error(e));
+            ExternalPtr::new(GraphView::Mpdag(Arc::new(mpdag)))
         }
         "UG" => {
             let ug = Ug::new(Arc::clone(&core_arc)).unwrap_or_else(|e| throw_r_error(e));

--- a/tests/testthat/test-operations.R
+++ b/tests/testthat/test-operations.R
@@ -820,7 +820,7 @@ test_that("meek_closure is idempotent and preserves node names", {
   c1 <- meek_closure(g)
   c2 <- meek_closure(c1)
 
-  expect_equal(c1@graph_class, "PDAG")
+  expect_equal(c1@graph_class, "MPDAG")
   expect_equal(nodes(c1)$name, nodes(g)$name)
   expect_equal(edges(c1), edges(c2))
 })
@@ -920,9 +920,9 @@ test_that("dag_from_pdag orients each undirected edge exactly once", {
   expect_equal(nrow(ed), 3L)
 })
 
-test_that("pgmpy Meek fixtures: rs_to_cpdag on PDAG applies Meek closure", {
+test_that("pgmpy Meek fixtures: meek_closure on PDAG applies Meek closure", {
   cpdag_from_pdag <- function(pdag) {
-    cp_session <- rs_to_cpdag(pdag@session)
+    cp_session <- rs_meek_closure(pdag@session)
     .session_to_caugi(cp_session, node_names = nodes(pdag)$name)
   }
   edge_set <- function(g) {

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -74,9 +74,9 @@ test_that("p branch draws edges via rbinom", {
   expect_identical(nrow(edges(g)), expected_m)
 })
 
-test_that("CPDAG class returns PDAG class and same nodes", {
+test_that("CPDAG class returns MPDAG class and same nodes", {
   g <- generate_graph(6, m = 5, class = "CPDAG")
-  expect_identical(g@graph_class, "PDAG")
+  expect_identical(g@graph_class, "MPDAG")
   expect_identical(nrow(nodes(g)), 6L)
 })
 
@@ -84,7 +84,7 @@ test_that("CPDAG generation returns a valid CPDAG with supported edge types", {
   set.seed(2026)
   g <- generate_graph(10, m = 14L, class = "CPDAG")
 
-  expect_identical(g@graph_class, "PDAG")
+  expect_identical(g@graph_class, "MPDAG")
   expect_true(is_pdag(g))
   expect_true(is_cpdag(g))
   expect_true(is_acyclic(g, force_check = TRUE))


### PR DESCRIPTION
This PR builds on db26d6e2, which introduced the `Mpdag` type but did not yet thread it through the dispatch layer. This is the second of three planned PRs. In the last one, the plan is to start using these new traits and the Mpdag struct inside an algorithm and benchmark to see what we gain. But even without performance gains, I think having Mpdag be a first-class citizen inside the Rust backend is exactly the right pattern. Maybe I will actually squeeze in a PR next to promote CPDAG to a first-class citizen too (on both the R and Rust side).

The summary below was generated by Claude:

## Summary

- **`Mpdag`is now reachable end-to-end.** Adds an `Mpdag(Arc<Mpdag>)` variant to
  `GraphView` and threads it through every match arm in `view.rs`. The class
  string reporter in `lib.rs` now returns `"MPDAG"` for the new variant.
- **`Dag::to_cpdag`and `Pdag::to_mpdag` now return `Mpdag`.** The result of any
  CPDAG/Meek-closure conversion carries type-level evidence of Meek closure.
- **Honest naming for transformation methods.** `Pdag::to_cpdag` is renamed to
  `Pdag::to_mpdag`: applying Meek's rules to a PDAG produces an MPDAG, not a
  CPDAG (which would additionally require chordal chain components and only
  compelled arrows). `view::to_cpdag` is restricted to `Dag` inputs; a new
  `view::to_mpdag` accepts `Dag` / `Pdag` / `Mpdag`.
- **R-visible change:** Meek-closed PDAGs are labeled `@graph_class = "MPDAG"`
  instead of `"PDAG"`. Surfaces in `meek_closure()` and
  `generate_graph(class = "CPDAG")`. Existing R-side predicates and verbs
  already accept `"MPDAG"`; no other user-facing API changes.

## Details

### Rust

- `GraphView` gains an `Mpdag(Arc<Mpdag>)` variant (`view.rs`). Every exhaustive
  `match self` block gets an `Mpdag` arm --- most forward via `m.as_pdag()`
  (zero-cost through the `Deref<Target=Pdag>` from PR 1).
- `induced_subgraph` on an `Mpdag` auto-downgrades to `Pdag` if the induced
  subgraph is no longer Meek-closed (closure is not preserved under arbitrary
  node deletions).
- `Pdag::to_cpdag` → `Pdag::to_mpdag` with an explicit doc note that a real
  PDAG→CPDAG would need a Dor-Tarsi DAG extension (not implemented). The
  domain-named `Pdag::meek_closure` alias remains and now delegates to
  `to_mpdag`.
- `view::to_cpdag` is `Dag`-only; `Pdag` / `Mpdag` inputs error with
  `"to_cpdag is only defined for DAGs"`. A new `view::to_mpdag` handles Meek
  closure for `Dag` (via `Dag::to_cpdag`), `Pdag` (via `to_mpdag`), and `Mpdag`
  (fixed-point).
- `session.rs` updates: `build_view`, `resolve_class`, and `is_mpdag` all route
  the MPDAG path through `Mpdag::try_new`; `meek_closure` wraps its result as
  `GraphView::Mpdag(...)`.
- `lib.rs` updates: `graph_class_label_from_view` and `graph_class_from_view`
  gain `Mpdag` arms; the dead-code `graphview_new` constructor splits `"PDAG"`
  (no closure check) from `"CPDAG" | "MPDAG"` (routes through `Mpdag::try_new`).

### R

- `tests/testthat/test-simulation.R`: two assertions updated from `"PDAG"` to
  `"MPDAG"`.
- `tests/testthat/test-operations.R`: the `meek_closure` test on `c1` now
  expects `"MPDAG"`; the pgmpy Meek-fixture helper switches from `rs_to_cpdag`
  to `rs_meek_closure` (the former is now DAG-only).
- `NEWS.md`: bullet under **Improvements** noting the class-label change.

## Out of scope

- **A real `Pdag::to_cpdag`**. This needs a PDAG-to-DAG extension algorithm
  (Dor-Tarsi 1992) plus a first-class `Cpdag` struct. Tracked separately.
- **`Cpdag`as its own type.** Once the extension lands, `Dag::to_cpdag` would
  return `Cpdag` honestly (rather than `Mpdag`).
- **Performance work.** Removing redundant `directed_part_is_acyclic` and
  Meek-closure round-trips on chained conversions is the planned next PR.