### PR TITLE
Various fixes for partially undirected edges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
 - Fix `dag_from_pdag()` failing with `` `from`, `edge`, `to` must be equal
   length. `` when a sink had multiple undirected neighbors (#298).
 
+- Fixed a bug causing a partially undirected (`--o`) edges to
+be plotted as undirected edges.
+
 # caugi 1.2.0
 
 ## New Features

--- a/R/as_caugi.R
+++ b/R/as_caugi.R
@@ -9,9 +9,9 @@
 #' have that `G["A", "B"] == 1` and `G["B", "A"] == 0`.
 #' For PAGs, the integer codes are as follows (as used in `pcalg`):
 #' - 0: no edge
-#' - 1: circle (e.g., `A o-o B` or `A o-- B`)
+#' - 1: circle (e.g., `A o-o B` or `A --o B`)
 #' - 2: arrowhead (e.g., `A --> B` or `A o-> B`)
-#' - 3: tail (e.g., `A o-- B` or `A --- B`)
+#' - 3: tail (e.g., `A --o B` or `A --- B`)
 #'
 #' @param x An object to convert to a `caugi`.
 #' @param class Character; one of `"DAG"`, `"UG"`, `"PDAG"`, `"MPDAG"`,

--- a/R/plot-grobs.R
+++ b/R/plot-grobs.R
@@ -533,7 +533,7 @@ makeContent.caugi_edge_grob <- function(x) {
       )
     }
 
-    if (x$edge_type == "o-o") {
+    if (x$edge_type == "o-o" || x$edge_type == "--o") {
       grob_list <- grid::gList(
         grob_list,
         grid::circleGrob(
@@ -582,6 +582,7 @@ make_edges <- function(
         "<->" = edge_styles$bidirected,
         "o->" = edge_styles$partial,
         "o-o" = edge_styles$partial,
+        "--o" = edge_styles$partial,
         edge_styles$undirected
       )
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -78,7 +78,7 @@ The available edges in `caugi` are listed below:
 * `%---%` (undirected)
 * `%<->%` (bidirected)
 * `%o->%` (partially directed)
-* `%o--%` (partially undirected)
+* `%--o%` (partially undirected)
 * `%o-o%` (partial)
 
 You can register more types with `register_caugi_edge()`, if you find that you need a more expressive set of edges. For example, if you want to represent a directed edge in the reverse direction, you can do so like this:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The available edges in `caugi` are listed below:
 - `%---%` (undirected)
 - `%<->%` (bidirected)
 - `%o->%` (partially directed)
-- `%o--%` (partially undirected)
+- `%--o%` (partially undirected)
 - `%o-o%` (partial)
 
 You can register more types with `register_caugi_edge()`, if you find

--- a/man/as_caugi.Rd
+++ b/man/as_caugi.Rd
@@ -45,9 +45,9 @@ have that \code{G["A", "B"] == 1} and \code{G["B", "A"] == 0}.
 For PAGs, the integer codes are as follows (as used in \code{pcalg}):
 \itemize{
 \item 0: no edge
-\item 1: circle (e.g., \verb{A o-o B} or \verb{A o-- B})
+\item 1: circle (e.g., \verb{A o-o B} or \verb{A --o B})
 \item 2: arrowhead (e.g., \verb{A --> B} or \verb{A o-> B})
-\item 3: tail (e.g., \verb{A o-- B} or \code{A --- B})
+\item 3: tail (e.g., \verb{A --o B} or \code{A --- B})
 }
 }
 \examples{


### PR DESCRIPTION
Fixes the following:

- Partially undirected edges was plotted as undirected edges.
- README used wrong syntax for partially undirected.
- `as_caugi()` documentation used wrong syntax for partially undirected.