### PR TITLE
Fix is_mag() returning incorrect results (#309)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
 - Fixed a bug causing a partially undirected (`--o`) edges to
 be plotted as undirected edges.
 
+- Fixed `is_mag()` returning incorrect results for some ancestral graphs.
+  Adjacency was tested by binary-searching the concatenation of separately
+  sorted neighbor buckets, which is not globally sorted, so some adjacent
+  pairs were missed (#309).
+
 # caugi 1.2.0
 
 ## New Features

--- a/src/rust/src/graph/ag/mod.rs
+++ b/src/rust/src/graph/ag/mod.rs
@@ -364,7 +364,13 @@ impl Ag {
 
     /// Check if two nodes are adjacent (connected by any edge).
     pub fn adjacent(&self, a: u32, b: u32) -> bool {
-        self.neighbors_of(a).binary_search(&b).is_ok()
+        // `neighbors_of` concatenates four individually-sorted buckets, so the
+        // combined slice is not globally sorted and cannot be binary-searched.
+        // Search each sorted bucket separately instead.
+        self.parents_of(a).binary_search(&b).is_ok()
+            || self.children_of(a).binary_search(&b).is_ok()
+            || self.spouses_of(a).binary_search(&b).is_ok()
+            || self.undirected_of(a).binary_search(&b).is_ok()
     }
 
     /// Check if this ancestral graph is maximal (MAG).
@@ -725,6 +731,33 @@ mod tests {
     }
 
     #[test]
+    fn ag_is_mag_complete_graph_issue_309() {
+        // Regression test for #309: a complete AG is trivially maximal (no
+        // non-adjacent pairs), but a buggy `adjacent` using binary_search over
+        // the unsorted concatenated neighborhood made `is_mag` return false.
+        // Graph (figure 4b): nodes X=0, Z=1, Y=2, W=3.
+        //   X <-> Z, X <-> Y, Z <-> W, Z --> Y, X --> W, Y <-> W
+        let (reg, dir, bid, _und) = setup();
+        let mut b = GraphBuilder::new_with_registry(4, true, &reg);
+        b.add_edge(0, 1, bid).unwrap(); // X <-> Z
+        b.add_edge(0, 2, bid).unwrap(); // X <-> Y
+        b.add_edge(1, 3, bid).unwrap(); // Z <-> W
+        b.add_edge(1, 2, dir).unwrap(); // Z --> Y
+        b.add_edge(0, 3, dir).unwrap(); // X --> W
+        b.add_edge(2, 3, bid).unwrap(); // Y <-> W
+
+        let ag = Ag::new(Arc::new(b.finalize().unwrap())).unwrap();
+
+        // Every pair is adjacent (complete graph).
+        for u in 0..4u32 {
+            for v in (u + 1)..4u32 {
+                assert!(ag.adjacent(u, v), "expected {u} and {v} to be adjacent");
+            }
+        }
+        assert!(ag.is_mag());
+    }
+
+    #[test]
     fn ag_core_ref() {
         let (reg, dir, _bid, _und) = setup();
         let mut b = GraphBuilder::new_with_registry(2, true, &reg);
@@ -880,7 +913,11 @@ mod tests {
                 code /= states;
             }
 
-            let ag = Ag::new(Arc::new(b.finalize().unwrap())).unwrap();
+            // Not every enumerated candidate is a valid AG (e.g. undirected
+            // constraint violations); skip those that fail construction.
+            let Ok(ag) = Ag::new(Arc::new(b.finalize().unwrap())) else {
+                continue;
+            };
             if !ag.is_mag() {
                 found_non_mag = true;
                 break 'search;

--- a/src/rust/src/graph/pdag/mod.rs
+++ b/src/rust/src/graph/pdag/mod.rs
@@ -183,7 +183,12 @@ impl Pdag {
 impl Pdag {
     #[inline]
     pub(crate) fn adjacent(&self, a: u32, b: u32) -> bool {
-        self.neighbors_of(a).binary_search(&b).is_ok()
+        // `neighbors_of` concatenates three individually-sorted buckets, so the
+        // combined slice is not globally sorted and cannot be binary-searched.
+        // Search each sorted bucket separately instead.
+        self.parents_of(a).binary_search(&b).is_ok()
+            || self.children_of(a).binary_search(&b).is_ok()
+            || self.undirected_of(a).binary_search(&b).is_ok()
     }
 
     #[inline]

--- a/tests/testthat/test-ag.R
+++ b/tests/testthat/test-ag.R
@@ -352,6 +352,24 @@ test_that("is_mag correctly identifies complete graph as MAG", {
   expect_true(is_mag(ag_complete))
 })
 
+test_that("is_mag identifies complete graph with mixed edges as MAG (#309)", {
+  # Regression test for #309 (figure 4b). This graph is complete, so it is
+  # trivially a MAG. A buggy `adjacent` that binary-searched the unsorted
+  # concatenation of neighbor buckets failed to detect some adjacencies (e.g.
+  # Z --> Y on a node whose child index sorts before its spouse indices),
+  # making `is_mag` wrongly return FALSE.
+  ag_309 <- caugi(
+    X %<->% Z + Y,
+    Z %<->% W,
+    Z %-->% Y,
+    X %-->% W,
+    Y %<->% W,
+    class = "AG"
+  )
+
+  expect_true(is_mag(ag_309))
+})
+
 # ─────────────────────────────────────────────────────────────────────────────
 # MAG - Mixed Edge Types
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adjacency in `Ag` (and `Pdag`) was tested by binary-searching the slice returned by `neighbors_of()`, which concatenates several individually sorted neighbor buckets. The concatenation is not globally sorted, so `binary_search` could miss a present neighbor and report adjacent nodes as non-adjacent. For the complete graph in #309 this `made is_mag()` return `FALSE`.

Search each sorted bucket separately instead. Also harden the AG enumeration test to skip candidates that are not valid ancestral graphs.

Add Rust and R regression tests covering the figure 4b graph from #309.

Closes #309.