### PR TITLE
Add jitter to tiered layout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@
 
 ## Improvements
 
+* `caugi_layout_tiered()` gains a `jitter` argument (default `0`). When set to
+  a positive value, nodes within the same tier are offset by alternating
+  +`jitter` / −`jitter` in the perpendicular direction.
 - Meek-closed PDAGs are now reported with `@graph_class = "MPDAG"` instead of
   `"PDAG"`. This affects the result of `meek_closure()` and
   `generate_graph(class = "CPDAG")`. Predicates and verbs defined on PDAGs

--- a/R/layout.R
+++ b/R/layout.R
@@ -324,6 +324,10 @@ caugi_layout_bipartite <- function(
 #'     subsequent tiers to the right, last tier at right (x=1).
 #'   * `"rows"`: Horizontal tiers. First tier at top (y=1),
 #'     subsequent tiers below, last tier at bottom (y=0).
+#' @param jitter Non-negative numeric. When greater than zero, nodes within
+#'   the same tier are offset in the perpendicular direction (y for `"rows"`,
+#'   x for `"columns"`) using an alternating +jitter / -jitter pattern.
+#'   Default is  `0` (no jitter).
 #'
 #' @returns A `data.frame` with columns `name`, `x`, `y`, and `tier` containing
 #'   node names, their coordinates, and tier assignments (0-indexed). The
@@ -362,6 +366,17 @@ caugi_layout_bipartite <- function(
 #' # The layout includes tier information, so plot() works without passing tiers
 #' plot(cg, layout = layout)
 #'
+#' # Jitter nodes within tiers to make within-tier edges visible
+#' cg_clique <- caugi(A %---% B + C, B %---% C)
+#' tiers_clique <- list(c("A", "B", "C"))
+#' layout_jitter <- caugi_layout_tiered(
+#'   cg_clique,
+#'   tiers_clique,
+#'   orientation = "rows",
+#'   jitter = 0.07
+#' )
+#' plot(cg_clique, layout = layout_jitter)
+#'
 #' @family plotting
 #' @concept plotting
 #'
@@ -369,11 +384,16 @@ caugi_layout_bipartite <- function(
 caugi_layout_tiered <- function(
   x,
   tiers,
-  orientation = c("columns", "rows")
+  orientation = c("columns", "rows"),
+  jitter = 0
 ) {
   is_caugi(x, throw_error = TRUE)
 
   orientation <- match.arg(orientation)
+
+  if (!is.numeric(jitter) || length(jitter) != 1 || jitter < 0) {
+    stop("jitter must be a single non-negative number", call. = FALSE)
+  }
 
   node_names <- nodes(x)[["name"]]
   n_nodes <- length(node_names)
@@ -519,8 +539,29 @@ caugi_layout_tiered <- function(
     stringsAsFactors = FALSE
   )
 
-  # Store orientation as attribute for plot() to use
+  if (jitter > 0) {
+    for (t in unique_tiers) {
+      tier_idx <- which(tier_assignments == t)
+      n_in_tier <- length(tier_idx)
+      if (n_in_tier < 2) {
+        next
+      }
+      if (orientation == "rows") {
+        ordered_idx <- tier_idx[order(result$x[tier_idx])]
+        offsets <- jitter * ifelse(seq_len(n_in_tier) %% 2 == 1, 1, -1)
+        result$y[ordered_idx] <- result$y[ordered_idx] + offsets
+      } else {
+        ordered_idx <- tier_idx[order(result$y[tier_idx])]
+        offsets <- jitter * ifelse(seq_len(n_in_tier) %% 2 == 1, 1, -1)
+        result$x[ordered_idx] <- result$x[ordered_idx] + offsets
+      }
+    }
+  }
+
+  # Store orientation and the intended [0,1] coordinate scale as attributes.
   attr(result, "orientation") <- orientation
+  attr(result, "x_scale") <- c(0, 1)
+  attr(result, "y_scale") <- c(0, 1)
 
   result
 }

--- a/R/plot-core.R
+++ b/R/plot-core.R
@@ -162,14 +162,26 @@ S7::method(plot, caugi) <- function(
 
   dots <- list(...)
 
+  # These are set to non-NULL by layout functions that use a fixed coordinate
+  # space (e.g. tiered layout), so the plot doesn't stretch the viewport to
+  # the actual data range.
+  layout_x_scale <- NULL
+  layout_y_scale <- NULL
+
   # Compute layout coordinates
   if (is.character(layout)) {
     # String method name - pass through to caugi_layout
     coords <- caugi_layout(x, method = layout, ...)
+    layout_x_scale <- attr(coords, "x_scale")
+    layout_y_scale <- attr(coords, "y_scale")
   } else if (is.function(layout)) {
     # Layout function - call directly with ...
     coords <- layout(x, ...)
+    layout_x_scale <- attr(coords, "x_scale")
+    layout_y_scale <- attr(coords, "y_scale")
   } else if (is.data.frame(layout)) {
+    layout_x_scale <- attr(layout, "x_scale")
+    layout_y_scale <- attr(layout, "y_scale")
     # Pre-computed layout - validate thoroughly
     required_cols <- c("name", "x", "y")
     missing_cols <- setdiff(required_cols, names(layout))
@@ -281,14 +293,21 @@ S7::method(plot, caugi) <- function(
   vp_width <- grid::unit(1, "npc")
   vp_height <- grid::unit(1, "npc")
 
-  x_range <- range(coords$x)
-  y_range <- range(coords$y)
-
-  if (x_range[1] == x_range[2]) {
-    x_range <- x_range + c(-1, 1)
+  if (!is.null(layout_x_scale)) {
+    x_range <- layout_x_scale
+  } else {
+    x_range <- range(coords$x)
+    if (x_range[1] == x_range[2]) {
+      x_range <- x_range + c(-1, 1)
+    }
   }
-  if (y_range[1] == y_range[2]) {
-    y_range <- y_range + c(-1, 1)
+  if (!is.null(layout_y_scale)) {
+    y_range <- layout_y_scale
+  } else {
+    y_range <- range(coords$y)
+    if (y_range[1] == y_range[2]) {
+      y_range <- y_range + c(-1, 1)
+    }
   }
 
   # Nodes

--- a/man/caugi_layout_tiered.Rd
+++ b/man/caugi_layout_tiered.Rd
@@ -4,7 +4,7 @@
 \alias{caugi_layout_tiered}
 \title{Tiered Graph Layout}
 \usage{
-caugi_layout_tiered(x, tiers, orientation = c("columns", "rows"))
+caugi_layout_tiered(x, tiers, orientation = c("columns", "rows"), jitter = 0)
 }
 \arguments{
 \item{x}{A \code{caugi} object.}
@@ -31,6 +31,11 @@ subsequent tiers to the right, last tier at right (x=1).
 \item \code{"rows"}: Horizontal tiers. First tier at top (y=1),
 subsequent tiers below, last tier at bottom (y=0).
 }}
+
+\item{jitter}{Non-negative numeric. When greater than zero, nodes within
+the same tier are offset in the perpendicular direction (y for \code{"rows"},
+x for \code{"columns"}) using an alternating +jitter / -jitter pattern.
+Default is  \code{0} (no jitter).}
 }
 \value{
 A \code{data.frame} with columns \code{name}, \code{x}, \code{y}, and \code{tier} containing
@@ -75,6 +80,17 @@ layout <- caugi_layout_tiered(cg, tiers, orientation = "rows")
 
 # The layout includes tier information, so plot() works without passing tiers
 plot(cg, layout = layout)
+
+# Jitter nodes within tiers to make within-tier edges visible
+cg_clique <- caugi(A \%---\% B + C, B \%---\% C)
+tiers_clique <- list(c("A", "B", "C"))
+layout_jitter <- caugi_layout_tiered(
+  cg_clique,
+  tiers_clique,
+  orientation = "rows",
+  jitter = 0.07
+)
+plot(cg_clique, layout = layout_jitter)
 
 }
 \seealso{

--- a/tests/testthat/test-tiered-layout.R
+++ b/tests/testthat/test-tiered-layout.R
@@ -689,3 +689,87 @@ test_that("tiered layout validation branches are covered", {
     "Nodes without tier assignments: C"
   )
 })
+
+test_that("jitter offsets nodes in perpendicular direction for rows", {
+  cg <- caugi(A %---% B + C, B %---% C)
+  tiers <- list(c("A", "B", "C"))
+
+  layout_no_jitter <- caugi_layout_tiered(cg, tiers, orientation = "rows")
+  layout_jitter <- caugi_layout_tiered(
+    cg,
+    tiers,
+    orientation = "rows",
+    jitter = 0.1
+  )
+
+  expect_equal(length(unique(layout_no_jitter$y)), 1)
+
+  expect_gt(length(unique(layout_jitter$y)), 1)
+
+  base_y <- unique(layout_no_jitter$y)
+  expect_equal(min(layout_jitter$y), base_y - 0.1)
+  expect_equal(max(layout_jitter$y), base_y + 0.1)
+
+  expect_equal(layout_jitter$x, layout_no_jitter$x)
+})
+
+test_that("jitter offsets nodes in perpendicular direction for columns", {
+  cg <- caugi(A %---% B + C, B %---% C)
+  tiers <- list(c("A", "B", "C"))
+
+  layout_no_jitter <- caugi_layout_tiered(cg, tiers, orientation = "columns")
+  layout_jitter <- caugi_layout_tiered(
+    cg,
+    tiers,
+    orientation = "columns",
+    jitter = 0.1
+  )
+
+  expect_equal(length(unique(layout_no_jitter$x)), 1)
+
+  expect_gt(length(unique(layout_jitter$x)), 1)
+
+  base_x <- unique(layout_no_jitter$x)
+  expect_equal(min(layout_jitter$x), base_x - 0.1)
+  expect_equal(max(layout_jitter$x), base_x + 0.1)
+
+  expect_equal(layout_jitter$y, layout_no_jitter$y)
+})
+
+test_that("jitter skips single-node tiers", {
+  cg <- caugi(A %-->% B, B %-->% C)
+  tiers <- list("A", c("B", "C"))
+
+  layout <- caugi_layout_tiered(cg, tiers, orientation = "rows", jitter = 0.1)
+
+  expect_equal(layout$y[layout$name == "A"], 1)
+
+  y_bc <- layout$y[layout$name %in% c("B", "C")]
+  expect_true(all(y_bc != 0))
+})
+
+test_that("jitter validates input", {
+  cg <- caugi(A %-->% B)
+  tiers <- list("A", "B")
+
+  expect_error(
+    caugi_layout_tiered(cg, tiers, jitter = -0.1),
+    "jitter must be a single non-negative number"
+  )
+
+  expect_error(
+    caugi_layout_tiered(cg, tiers, jitter = "big"),
+    "jitter must be a single non-negative number"
+  )
+})
+
+test_that("plot works with jittered tiered layout", {
+  cg <- caugi(A %---% B + C, B %---% C)
+  tiers <- list(c("A", "B", "C"))
+
+  layout <- caugi_layout_tiered(cg, tiers, orientation = "rows", jitter = 0.07)
+
+  expect_no_error({
+    p <- plot(cg, layout = layout, tier_style = list(boxes = TRUE))
+  })
+})


### PR DESCRIPTION
Adds an arg jitter to tiered plots, so you can actually see the edges in a tiered plot. E.g. before you could have in the same tier A --- B + C, and you would not be able to tell it apart from A --- C, since the A --- C edge would pass through B.

Could maybe consider doing some auto-checking for this and doing it automatically, but this is fine for now probably?