### PR TITLE
feat(plot): automatically route edges around non-incident nodes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New Features
 
+- `plot()` now automatically bends edges around non-incident nodes that they
+  would otherwise pass straight through, so edges between collinear nodes (e.g.
+  within a tier) and edges crossing unrelated nodes stay visible. This is
+  controlled by `edge_style$route` (default `TRUE`); disable it with
+  `edge_style = list(route = FALSE)`, or per edge type/edge via the usual
+  `edge_style` overrides.
 - Add `==` and `!=` methods for `caugi` objects so `cg1 == cg2` returns a single
   logical comparing graph content (class, nodes, edges, `simple`) rather than
   session identity.

--- a/R/options.R
+++ b/R/options.R
@@ -32,7 +32,8 @@ caugi_default_options <- function() {
       edge_style = list(
         arrow_size = 3,
         circle_size = 1.5,
-        fill = "black"
+        fill = "black",
+        route = TRUE
       ),
       label_style = list(),
       title_style = list(
@@ -89,6 +90,8 @@ caugi_default_options <- function() {
 #'   - `arrow_size`: Arrow size in mm (default: `3`)
 #'   - `circle_size`: Radius of endpoint circles for partial edges in mm (default: `1.5`)
 #'   - `fill`: Arrow/line color (default: `"black"`)
+#'   - `route`: Whether edges automatically bend around non-incident nodes they
+#'     would otherwise cross (default: `TRUE`)
 #' - `label_style`: List of label text parameters (see [grid::gpar()])
 #' - `title_style`: List of title text parameters:
 #'   - `col`: Text color (default: `"black"`)

--- a/R/plot-core.R
+++ b/R/plot-core.R
@@ -30,7 +30,9 @@
 #'   Supports:
 #'   * Appearance (passed to `gpar()`): `col`, `lwd`, `lty`, `alpha`, `fill`.
 #'   * Geometry: `arrow_size` (arrow length in mm, default 3), `circle_size`
-#'     (radius of endpoint circles for partial edges in mm, default 1.5)
+#'     (radius of endpoint circles for partial edges in mm, default 1.5),
+#'     `route` (logical, default `TRUE`; when `TRUE`, edges automatically bend
+#'     around non-incident nodes they would otherwise pass through)
 #'   * Local overrides via `by_edge`: a named list with:
 #'       - Node-wide styles: applied to all edges touching a node, e.g.
 #'         `A = list(col = "red", lwd = 2)`

--- a/R/plot-grobs.R
+++ b/R/plot-grobs.R
@@ -385,6 +385,11 @@ make_nodes <- function(coords, labels, node_style, label_style) {
 # @param arrow Optional arrow specification from grid::arrow()
 # @param gp Graphics parameters from grid::gpar()
 # @param name Optional grob name
+# @param obstacle_x,obstacle_y Native coordinates of candidate obstacle node
+#   centers (all nodes other than this edge's endpoints). Used at draw time to
+#   route the edge around nodes it would otherwise cross.
+# @param obstacle_r List of node radii (grid units) matching obstacle_x/y.
+# @param route Logical; whether to bend the edge around obstacles (default TRUE).
 #
 # @returns A gTree of class "caugi_edge_grob"
 make_edge_grob <- function(
@@ -398,7 +403,11 @@ make_edge_grob <- function(
   gp = grid::gpar(),
   name = NULL,
   edge_type = NULL,
-  circle_size = 1.5
+  circle_size = 1.5,
+  obstacle_x = numeric(0),
+  obstacle_y = numeric(0),
+  obstacle_r = list(),
+  route = TRUE
 ) {
   grid::gTree(
     x0 = x0,
@@ -412,6 +421,10 @@ make_edge_grob <- function(
     name = name,
     edge_type = edge_type,
     circle_size = circle_size,
+    obstacle_x = obstacle_x,
+    obstacle_y = obstacle_y,
+    obstacle_r = obstacle_r,
+    route = route,
     cl = "caugi_edge_grob"
   )
 }
@@ -476,13 +489,85 @@ makeContent.caugi_edge_grob <- function(x) {
     y1_adj <- y1_unit
   }
 
-  # Create line grob
-  line_grob <- grid::linesGrob(
-    x = grid::unit.c(x0_adj, x1_adj),
-    y = grid::unit.c(y0_adj, y1_adj),
-    arrow = x$arrow,
-    gp = x$gp
-  )
+  # Route the edge around any non-incident nodes it would otherwise cross.
+  # Detection and curve construction happen in mm, since the layout's native
+  # [0, 1] space is aspect-distorted. The curve is built between node centers
+  # and clipped to the borders, so the edge projects radially from each center.
+  path <- NULL
+  # Endpoint tangents (mm): default to the straight-line direction.
+  t0 <- c(ux_mm, uy_mm)
+  t1 <- c(ux_mm, uy_mm)
+
+  if (isTRUE(x$route) && length_mm > 0 && length(x$obstacle_x) > 0) {
+    c0x <- grid::convertX(x0_unit, "mm", valueOnly = TRUE)
+    c0y <- grid::convertY(y0_unit, "mm", valueOnly = TRUE)
+    c1x <- grid::convertX(x1_unit, "mm", valueOnly = TRUE)
+    c1y <- grid::convertY(y1_unit, "mm", valueOnly = TRUE)
+
+    ox <- grid::convertX(
+      grid::unit(x$obstacle_x, "native"),
+      "mm",
+      valueOnly = TRUE
+    )
+    oy <- grid::convertY(
+      grid::unit(x$obstacle_y, "native"),
+      "mm",
+      valueOnly = TRUE
+    )
+    or <- vapply(
+      x$obstacle_r,
+      function(r) grid::convertWidth(r, "mm", valueOnly = TRUE),
+      numeric(1)
+    )
+
+    lwd_pt <- x$gp$lwd %||% 1
+    line_hw_mm <- (lwd_pt / 72.27 * 25.4) / 2
+    clearance <- line_hw_mm + 1.0
+
+    path <- route_edge_path(
+      c0x,
+      c0y,
+      c1x,
+      c1y,
+      r_from_mm,
+      r_to_mm,
+      ox,
+      oy,
+      or,
+      clearance
+    )
+  }
+
+  # Create line grob (curved polyline if routed, straight line otherwise).
+  if (is.null(path)) {
+    line_grob <- grid::linesGrob(
+      x = grid::unit.c(x0_adj, x1_adj),
+      y = grid::unit.c(y0_adj, y1_adj),
+      arrow = x$arrow,
+      gp = x$gp
+    )
+  } else {
+    line_grob <- grid::linesGrob(
+      x = grid::unit(path$x, "mm"),
+      y = grid::unit(path$y, "mm"),
+      arrow = x$arrow,
+      gp = x$gp
+    )
+
+    # Endpoint tangents from the first/last sampled segments, so endpoint
+    # circles sit tangent to the curve.
+    m <- length(path$x)
+    d0 <- c(path$x[2] - path$x[1], path$y[2] - path$y[1])
+    d1 <- c(path$x[m] - path$x[m - 1], path$y[m] - path$y[m - 1])
+    n0 <- sqrt(sum(d0^2))
+    n1 <- sqrt(sum(d1^2))
+    if (n0 > 0) {
+      t0 <- d0 / n0
+    }
+    if (n1 > 0) {
+      t1 <- d1 / n1
+    }
+  }
 
   # Add circles for o-> and o-o edges
   grob_list <- grid::gList(line_grob)
@@ -495,23 +580,29 @@ makeContent.caugi_edge_grob <- function(x) {
       valueOnly = TRUE
     )
 
-    # Place circle centers just outside the node boundary.
-    # x0_adj/x1_adj are already at the node boundary, so we offset by the
-    # circle radius.
-    if (length_mm > 0) {
+    # Place circle centers just outside the node boundary, offset by the
+    # circle radius along the (curve) tangent at each endpoint. For a routed
+    # edge the endpoints are the clipped curve ends (in mm); otherwise they are
+    # the straight-line clip points (in native units).
+    if (!is.null(path)) {
+      circle_x0 <- grid::unit(path$x[1] + t0[1] * circle_radius_mm, "mm")
+      circle_y0 <- grid::unit(path$y[1] + t0[2] * circle_radius_mm, "mm")
+      circle_x1 <- grid::unit(path$x[m] - t1[1] * circle_radius_mm, "mm")
+      circle_y1 <- grid::unit(path$y[m] - t1[2] * circle_radius_mm, "mm")
+    } else if (length_mm > 0) {
       circle_x0 <- x0_adj +
-        grid::convertWidth(grid::unit(ux_mm * circle_radius_mm, "mm"), "native")
+        grid::convertWidth(grid::unit(t0[1] * circle_radius_mm, "mm"), "native")
       circle_y0 <- y0_adj +
         grid::convertHeight(
-          grid::unit(uy_mm * circle_radius_mm, "mm"),
+          grid::unit(t0[2] * circle_radius_mm, "mm"),
           "native"
         )
 
       circle_x1 <- x1_adj -
-        grid::convertWidth(grid::unit(ux_mm * circle_radius_mm, "mm"), "native")
+        grid::convertWidth(grid::unit(t1[1] * circle_radius_mm, "mm"), "native")
       circle_y1 <- y1_adj -
         grid::convertHeight(
-          grid::unit(uy_mm * circle_radius_mm, "mm"),
+          grid::unit(t1[2] * circle_radius_mm, "mm"),
           "native"
         )
     } else {
@@ -571,6 +662,10 @@ make_edges <- function(
 
       r_from <- node_radii[[from_idx]]
       r_to <- node_radii[[to_idx]]
+
+      # Every other node is a candidate obstacle for routing. Exclude the two
+      # endpoints by index (robust to duplicate coordinates).
+      obstacle_idx <- setdiff(seq_len(nrow(coords)), c(from_idx, to_idx))
 
       edge_type <- edges$edge[i]
 
@@ -668,7 +763,11 @@ make_edges <- function(
         gp = edge_gpar,
         name = paste0("edge.", i),
         edge_type = edge_type,
-        circle_size = style$circle_size
+        circle_size = style$circle_size,
+        obstacle_x = coords$x[obstacle_idx],
+        obstacle_y = coords$y[obstacle_idx],
+        obstacle_r = node_radii[obstacle_idx],
+        route = isTRUE(style$route)
       )
     }
   }

--- a/R/plot-routing.R
+++ b/R/plot-routing.R
@@ -1,0 +1,203 @@
+# Edge routing geometry helpers
+#
+# These functions are deliberately pure: they operate on plain numeric
+# coordinates (in millimeters) with no dependency on grid graphics state, so
+# they can be unit tested without an open graphics device. They are used by
+# `makeContent.caugi_edge_grob()` (R/plot-grobs.R) at draw time to bend edges
+# around non-incident nodes that the straight edge would otherwise cross.
+
+# Distance from a point to a line segment.
+#
+# Computes the Euclidean distance from point `(px, py)` to the segment
+# `(ax, ay)`--`(bx, by)`, together with the clamped projection parameter `t`
+# in `[0, 1]` locating the closest point on the segment
+# (`(ax, ay) + t * ((bx, by) - (ax, ay))`).
+#
+# @param px,py Point coordinates.
+# @param ax,ay,bx,by Segment endpoint coordinates.
+#
+# @returns A list with `dist` (numeric distance) and `t` (numeric in `[0, 1]`).
+#
+# @keywords internal
+.point_segment_dist <- function(px, py, ax, ay, bx, by) {
+  dx <- bx - ax
+  dy <- by - ay
+  l2 <- dx * dx + dy * dy
+
+  if (l2 <= 0) {
+    # Degenerate (zero-length) segment: distance to the single point.
+    t <- 0
+    cx <- ax
+    cy <- ay
+  } else {
+    t <- ((px - ax) * dx + (py - ay) * dy) / l2
+    t <- max(0, min(1, t))
+    cx <- ax + t * dx
+    cy <- ay + t * dy
+  }
+
+  list(dist = sqrt((px - cx)^2 + (py - cy)^2), t = t)
+}
+
+# Compute a routed edge path that avoids obstructing nodes.
+#
+# Works entirely in millimeters. The curve is built between the two node
+# *centers* `(p0x, p0y)` and `(p2x, p2y)` so that, after clipping to the node
+# borders, the edge appears to project radially from each center. The straight
+# center-to-center segment is tested against a set of obstacle nodes (circle
+# centers `(ox, oy)` with radii `or`). If no obstacle is closer than
+# `or + clearance`, no routing is needed and the function returns `NULL`.
+# Otherwise it builds a cubic Bezier bowed perpendicular to the chord, away
+# from the worst-violating obstacle, by enough to clear it. The
+# curve is then clipped to each node boundary (trimming the parts within
+# `r_from` of `(p0x, p0y)` and within `r_to` of `(p2x, p2y)`) and the surviving
+# arc is returned sampled into `n` points.
+#
+# @param p0x,p0y,p2x,p2y Node *center* coordinates in mm.
+# @param r_from,r_to Node radii in mm (used to clip the curve to the borders).
+# @param ox,oy Numeric vectors of obstacle center coordinates in mm.
+# @param or Numeric vector of obstacle radii in mm.
+# @param clearance Extra mm of margin required beyond each obstacle radius.
+# @param n Number of points to sample along the clipped curve (default 40).
+#
+# @returns A list with numeric vectors `x` and `y` of length `n` (the first and
+#   last points lying on the respective node borders), or `NULL` when no
+#   routing is needed or the curve cannot be fit between the borders.
+#
+# @keywords internal
+route_edge_path <- function(
+  p0x,
+  p0y,
+  p2x,
+  p2y,
+  r_from,
+  r_to,
+  ox,
+  oy,
+  or,
+  clearance,
+  n = 40L
+) {
+  n_obs <- length(ox)
+  if (n_obs == 0) {
+    return(NULL)
+  }
+
+  dx <- p2x - p0x
+  dy <- p2y - p0y
+  seg_len <- sqrt(dx * dx + dy * dy)
+  if (seg_len <= 0) {
+    return(NULL)
+  }
+
+  # Find the worst violator: the obstacle whose required clearance is most
+  # exceeded by its proximity to the center-to-center segment.
+  worst_k <- 0L
+  worst_violation <- 0
+  worst_side <- 1
+  worst_t <- 0.5
+
+  for (i in seq_len(n_obs)) {
+    ps <- .point_segment_dist(ox[i], oy[i], p0x, p0y, p2x, p2y)
+    needed <- or[i] + clearance
+    violation <- needed - ps$dist
+    if (violation > worst_violation) {
+      worst_violation <- violation
+      worst_k <- i
+      worst_t <- ps$t
+      # Signed side of the obstacle relative to the directed chord P0->P2
+      # (cross product z-component): +1 left, -1 right.
+      worst_side <- sign(dx * (oy[i] - p0y) - dy * (ox[i] - p0x))
+      if (worst_side == 0) {
+        worst_side <- 1
+      }
+    }
+  }
+
+  if (worst_k == 0L) {
+    return(NULL)
+  }
+
+  # Unit perpendicular to the chord, pointing away from the obstacle.
+  bend <- -worst_side
+  nperp_x <- bend * -dy / seg_len
+  nperp_y <- bend * dx / seg_len
+
+  # Build a cubic Bezier bowed away from the obstacle. Compared with a
+  # quadratic, placing the control handles only partway along the chord
+  # (`handle_frac`) makes the curve leave each node at a steeper angle, so it
+  # reads as projecting from the center and its endpoint marks separate from
+  # other edges meeting the same node. `h` is the perpendicular offset of the
+  # control points; it is sized so the curve clears the obstacle (whose
+  # required perpendicular displacement is `worst_violation`) at its projection
+  # `worst_t`, where the cubic reaches `3 * t * (1 - t) * h`.
+  handle_frac <- 0.2
+  tt <- max(0.15, min(0.85, worst_t))
+  h <- (worst_violation + 0.5) / (3 * tt * (1 - tt))
+  # Also bow at least a little so short, barely-grazing edges still curve
+  # visibly rather than looking kinked.
+  h <- max(h, 0.06 * seg_len)
+
+  p1x <- p0x + handle_frac * dx + h * nperp_x
+  p1y <- p0y + handle_frac * dy + h * nperp_y
+  p2cx <- p0x + (1 - handle_frac) * dx + h * nperp_x
+  p2cy <- p0y + (1 - handle_frac) * dy + h * nperp_y
+
+  qx <- function(u) {
+    (1 - u)^3 *
+      p0x +
+      3 * (1 - u)^2 * u * p1x +
+      3 * (1 - u) * u^2 * p2cx +
+      u^3 * p2x
+  }
+  qy <- function(u) {
+    (1 - u)^3 *
+      p0y +
+      3 * (1 - u)^2 * u * p1y +
+      3 * (1 - u) * u^2 * p2cy +
+      u^3 * p2y
+  }
+  d_from <- function(u) sqrt((qx(u) - p0x)^2 + (qy(u) - p0y)^2)
+  d_to <- function(u) sqrt((qx(u) - p2x)^2 + (qy(u) - p2y)^2)
+
+  # If a node is large enough to swallow the whole curve, give up and let the
+  # caller fall back to the straight (clipped) edge.
+  if (d_from(1) <= r_from || d_to(0) <= r_to) {
+    return(NULL)
+  }
+
+  # Clip to the node borders by bisection: the distance from each center grows
+  # monotonically as we move into the curve, so we can locate the parameter at
+  # which the curve crosses each border.
+  u_start <- .bisect_u(d_from, r_from, increasing = TRUE)
+  u_end <- .bisect_u(d_to, r_to, increasing = FALSE)
+  if (u_start >= u_end) {
+    return(NULL)
+  }
+
+  u <- seq(u_start, u_end, length.out = n)
+  list(x = qx(u), y = qy(u))
+}
+
+# Locate the curve parameter where a (monotone) distance function crosses a
+# target value, via bisection on `[0, 1]`.
+#
+# When `increasing = TRUE`, `f` grows from 0 at `u = 0`; we return the smallest
+# `u` with `f(u) >= target`. When `increasing = FALSE`, `f` grows toward `u = 0`
+# (it is 0 at `u = 1`); we return the largest `u` with `f(u) >= target`.
+#
+# @keywords internal
+.bisect_u <- function(f, target, increasing) {
+  lo <- 0
+  hi <- 1
+  for (k in seq_len(40)) {
+    mid <- (lo + hi) / 2
+    inside <- f(mid) < target
+    if (increasing) {
+      if (inside) lo <- mid else hi <- mid
+    } else {
+      if (inside) hi <- mid else lo <- mid
+    }
+  }
+  if (increasing) hi else lo
+}

--- a/man/caugi_options.Rd
+++ b/man/caugi_options.Rd
@@ -45,6 +45,8 @@ The plot options are nested under the \code{plot} key:
 \item \code{arrow_size}: Arrow size in mm (default: \code{3})
 \item \code{circle_size}: Radius of endpoint circles for partial edges in mm (default: \code{1.5})
 \item \code{fill}: Arrow/line color (default: \code{"black"})
+\item \code{route}: Whether edges automatically bend around non-incident nodes they
+would otherwise cross (default: \code{TRUE})
 }
 \item \code{label_style}: List of label text parameters (see \code{\link[grid:gpar]{grid::gpar()}})
 \item \code{title_style}: List of title text parameters:

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -38,7 +38,9 @@ Supports:
 \itemize{
 \item Appearance (passed to \code{gpar()}): \code{col}, \code{lwd}, \code{lty}, \code{alpha}, \code{fill}.
 \item Geometry: \code{arrow_size} (arrow length in mm, default 3), \code{circle_size}
-(radius of endpoint circles for partial edges in mm, default 1.5)
+(radius of endpoint circles for partial edges in mm, default 1.5),
+\code{route} (logical, default \code{TRUE}; when \code{TRUE}, edges automatically bend
+around non-incident nodes they would otherwise pass through)
 \item Local overrides via \code{by_edge}: a named list with:
 \itemize{
 \item Node-wide styles: applied to all edges touching a node, e.g.

--- a/tests/testthat/test-plot-routing.R
+++ b/tests/testthat/test-plot-routing.R
@@ -1,0 +1,224 @@
+# Tests for the pure edge-routing geometry helpers in R/plot-routing.R.
+# These operate on plain mm doubles and need no graphics device.
+
+test_that(".point_segment_dist measures perpendicular foot inside segment", {
+  res <- .point_segment_dist(5, 3, 0, 0, 10, 0)
+  expect_equal(res$dist, 3)
+  expect_equal(res$t, 0.5)
+})
+
+test_that(".point_segment_dist clamps past the endpoints", {
+  before_a <- .point_segment_dist(-4, 0, 0, 0, 10, 0)
+  expect_equal(before_a$t, 0)
+  expect_equal(before_a$dist, 4)
+
+  past_b <- .point_segment_dist(13, 0, 0, 0, 10, 0)
+  expect_equal(past_b$t, 1)
+  expect_equal(past_b$dist, 3)
+})
+
+test_that(".point_segment_dist handles a zero-length segment", {
+  res <- .point_segment_dist(4, 5, 1, 1, 1, 1)
+  expect_equal(res$t, 0)
+  expect_equal(res$dist, 5)
+})
+
+test_that("route_edge_path returns NULL when the obstacle is far away", {
+  path <- route_edge_path(
+    0,
+    0,
+    10,
+    0,
+    r_from = 0,
+    r_to = 0,
+    ox = 5,
+    oy = 50,
+    or = 1,
+    clearance = 1
+  )
+  expect_null(path)
+})
+
+test_that("route_edge_path returns NULL when there are no obstacles", {
+  path <- route_edge_path(
+    0,
+    0,
+    10,
+    0,
+    r_from = 0,
+    r_to = 0,
+    ox = numeric(0),
+    oy = numeric(0),
+    or = numeric(0),
+    clearance = 1
+  )
+  expect_null(path)
+})
+
+test_that("route_edge_path bends the curve clear of an on-segment obstacle", {
+  ox <- 5
+  oy <- 0
+  or <- 1
+  clearance <- 1
+  path <- route_edge_path(
+    0,
+    0,
+    10,
+    0,
+    r_from = 0,
+    r_to = 0,
+    ox = ox,
+    oy = oy,
+    or = or,
+    clearance = clearance
+  )
+
+  expect_type(path, "list")
+  expect_named(path, c("x", "y"))
+
+  # The closest approach of the sampled curve to the obstacle center must
+  # respect the required clearance.
+  dists <- sqrt((path$x - ox)^2 + (path$y - oy)^2)
+  expect_gte(min(dists), or + clearance)
+})
+
+test_that("route_edge_path bends to the side opposite the obstacle", {
+  # Obstacle above the chord -> curve apex should dip below it (negative y).
+  above <- route_edge_path(
+    0,
+    0,
+    10,
+    0,
+    r_from = 0,
+    r_to = 0,
+    ox = 5,
+    oy = 0.5,
+    or = 1,
+    clearance = 1
+  )
+  expect_lt(min(above$y), 0)
+
+  # Obstacle below the chord -> curve apex should rise above it (positive y).
+  below <- route_edge_path(
+    0,
+    0,
+    10,
+    0,
+    r_from = 0,
+    r_to = 0,
+    ox = 5,
+    oy = -0.5,
+    or = 1,
+    clearance = 1
+  )
+  expect_gt(max(below$y), 0)
+})
+
+test_that("route_edge_path keeps the curve endpoints at the node centers", {
+  # With zero radii there is no clipping, so the curve spans center to center.
+  path <- route_edge_path(
+    2,
+    3,
+    12,
+    9,
+    r_from = 0,
+    r_to = 0,
+    ox = 7,
+    oy = 6,
+    or = 1,
+    clearance = 1
+  )
+  expect_equal(path$x[1], 2)
+  expect_equal(path$y[1], 3)
+  expect_equal(path$x[length(path$x)], 12)
+  expect_equal(path$y[length(path$y)], 9)
+})
+
+test_that("route_edge_path clips the curve to the node borders", {
+  # Non-zero radii: the endpoints should sit on each node's border, i.e. at
+  # distance r_from / r_to from the respective center.
+  p0 <- c(0, 0)
+  p2 <- c(10, 0)
+  path <- route_edge_path(
+    p0[1],
+    p0[2],
+    p2[1],
+    p2[2],
+    r_from = 1.5,
+    r_to = 2,
+    ox = 5,
+    oy = 0,
+    or = 1,
+    clearance = 1
+  )
+
+  d_start <- sqrt((path$x[1] - p0[1])^2 + (path$y[1] - p0[2])^2)
+  m <- length(path$x)
+  d_end <- sqrt((path$x[m] - p2[1])^2 + (path$y[m] - p2[2])^2)
+  expect_equal(d_start, 1.5, tolerance = 1e-3)
+  expect_equal(d_end, 2, tolerance = 1e-3)
+})
+
+test_that("route_edge_path samples the requested number of points", {
+  path <- route_edge_path(
+    0,
+    0,
+    10,
+    0,
+    r_from = 0,
+    r_to = 0,
+    ox = 5,
+    oy = 0,
+    or = 1,
+    clearance = 1,
+    n = 25L
+  )
+  expect_length(path$x, 25L)
+  expect_length(path$y, 25L)
+})
+
+test_that("makeContent curves an edge around an on-path obstacle", {
+  pdf(NULL)
+  on.exit(dev.off())
+  grid::pushViewport(grid::viewport(xscale = c(0, 1), yscale = c(0, 1)))
+
+  obstacle <- list(
+    obstacle_x = 0.5,
+    obstacle_y = 0.5,
+    obstacle_r = list(grid::unit(4, "mm"))
+  )
+
+  routed <- make_edge_grob(
+    x0 = 0,
+    y0 = 0.5,
+    x1 = 1,
+    y1 = 0.5,
+    r_from = grid::unit(3, "mm"),
+    r_to = grid::unit(3, "mm"),
+    gp = grid::gpar(col = "black", lwd = 1),
+    edge_type = "-->",
+    obstacle_x = obstacle$obstacle_x,
+    obstacle_y = obstacle$obstacle_y,
+    obstacle_r = obstacle$obstacle_r,
+    route = TRUE
+  )
+  routed_line <- grid::makeContent(routed)$children[[1]]
+  expect_gt(length(routed_line$x), 2)
+
+  straight <- make_edge_grob(
+    x0 = 0,
+    y0 = 0.5,
+    x1 = 1,
+    y1 = 0.5,
+    r_from = grid::unit(3, "mm"),
+    r_to = grid::unit(3, "mm"),
+    gp = grid::gpar(col = "black", lwd = 1),
+    edge_type = "-->",
+    obstacle_x = obstacle$obstacle_x,
+    obstacle_y = obstacle$obstacle_y,
+    obstacle_r = obstacle$obstacle_r,
+    route = FALSE
+  )
+  straight_line <- grid::makeContent(straight)$children[[1]]
+  expect_length(straight_line$x, 2)
+})

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -914,3 +914,58 @@ test_that("plot layout validation branch is covered", {
     "and 2 more"
   )
 })
+
+test_that("plot routes edges around collinear nodes by default", {
+  cg <- caugi(A %---% B + C, B %---% C)
+  layout <- caugi_layout_tiered(
+    cg,
+    list(c("A", "B", "C")),
+    orientation = "rows"
+  )
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  # Routing on by default
+  expect_s7_class(plot(cg, layout = layout), caugi_plot)
+  # Routing can be disabled globally
+  expect_s7_class(
+    plot(cg, layout = layout, edge_style = list(route = FALSE)),
+    caugi_plot
+  )
+})
+
+test_that("plot routing works for partial edge types", {
+  cg <- caugi(A %o-o% B + C, B %o-o% C, class = "UNKNOWN")
+  layout <- caugi_layout_tiered(
+    cg,
+    list(c("A", "B", "C")),
+    orientation = "rows"
+  )
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  expect_s7_class(plot(cg, layout = layout), caugi_plot)
+})
+
+test_that("plot routing can be disabled per edge type", {
+  cg <- caugi(A %-->% B + C, B %-->% C, class = "DAG")
+  layout <- caugi_layout_tiered(
+    cg,
+    list(c("A", "B", "C")),
+    orientation = "rows"
+  )
+
+  pdf(NULL)
+  on.exit(dev.off())
+
+  expect_s7_class(
+    plot(
+      cg,
+      layout = layout,
+      edge_style = list(directed = list(route = FALSE))
+    ),
+    caugi_plot
+  )
+})

--- a/vignettes/visualization.Rmd
+++ b/vignettes/visualization.Rmd
@@ -480,8 +480,48 @@ Available edge style parameters:
 
 - **Appearance (passed to `gpar()`)**: `col`, `lwd`, `lty`, `alpha`, `fill`
 - **Geometry**: `arrow_size` (arrow length in mm), `circle_size` (radius of
-  endpoint circles for partial edges in mm)
+  endpoint circles for partial edges in mm), `route` (logical, automatic edge
+  routing; see below)
 - **Per-type options**: `directed`, `undirected`, `bidirected`, `partial`
+
+#### Automatic Edge Routing
+
+When an edge would pass straight through a node it does not connect to, the
+edge is hard to distinguish from edges that actually touch that node. This
+happens most often with collinear nodes—for example three nodes in the same
+tier, where the edge between the outer two runs right through the middle one—but
+also whenever a long edge happens to cross an unrelated node.
+
+By default (`route = TRUE`), `plot()` detects these cases from the node
+positions and sizes and gently bends the offending edge around the node, leaving
+all node positions untouched:
+
+```{r}
+#| label: edge-routing
+#| fig-height: 3
+
+cg_clique <- caugi(A %---% B + C, B %---% C)
+tiers_clique <- list(c("A", "B", "C"))
+layout_clique <- caugi_layout_tiered(
+  cg_clique,
+  tiers_clique,
+  orientation = "rows"
+)
+
+# A --- C bends around B (default); set route = FALSE to draw straight edges
+plot(cg_clique, layout = layout_clique)
+```
+
+Because routing is a draw-time operation, it works the same whether you let
+`plot()` compute the layout or pass a pre-computed one. Disable it globally, by
+edge type, or per edge through the usual `edge_style` overrides:
+
+```{r}
+#| label: edge-routing-off
+#| fig-height: 3
+
+plot(cg_clique, layout = layout_clique, edge_style = list(route = FALSE))
+```
 
 #### Partial Edges
 
@@ -877,7 +917,7 @@ The following options can be configured under `plot`:
 
 - **`spacing`**: A `grid::unit()` controlling space between composed plots
 - **`node_style`**: List with `fill`, `padding`, and `size`
-- **`edge_style`**: List with `arrow_size` and `fill`
+- **`edge_style`**: List with `arrow_size`, `circle_size`, `fill`, and `route`
 - **`label_style`**: List of text parameters (see `grid::gpar()`)
 - **`title_style`**: List with `col`, `fontface`, and `fontsize`
 


### PR DESCRIPTION
Edges that would visually pass through a node they don't connect to are now bent around it at draw time, controlled by `edge_style$route` (default `TRUE`). Detection is geometric (point-to-segment distance vs. node radius, in mm) so it handles both collinear within-tier edges and diagonal edges crossing unrelated nodes.

The curve is built between node centers and clipped to each border along its own tangent, so the edge projects radially from the center and the endpoint marks of partial edges (o->, o-o, --o) separate from other edges
meeting the same node. Routing is a pure draw-time operation, so it works
identically for `plot(cg)` and the two-step `caugi_layout()` -> `plot()` flow.

Geometry lives in pure, device-free helpers (`R/plot-routing.R`) with unit tests; adds plot smoke tests, NEWS, and a visualization vignette section.

This is an alternative to #320, which uses a manual jitter knob.

``` r
library(caugi)

cg <- caugi(A %---% B + C, B %---% C)
tiers <- list(c("A", "B", "C"))
lay <- caugi_layout_tiered(cg, tiers, orientation = "rows")

plot(cg, layout = lay) # routed (default): A--C arcs around B
```

![](https://i.imgur.com/CQcb8Z0.png)<!-- -->

``` r
plot(cg, layout = lay, edge_style = list(route = FALSE)) # straight: overlaps B
```

![](https://i.imgur.com/vvtZ7Wq.png)<!-- -->

``` r

# Side-by-side comparison (uses plot composition):
plot(cg, layout = lay, main = "route = TRUE") +
  plot(
  cg,
  layout = lay,
  edge_style = list(route = FALSE),
  main = "route = FALSE"
)
```

![](https://i.imgur.com/mrXNEMS.png)<!-- -->

``` r

# Same idea with a vertical tier (orientation = "columns").
lay_col <- caugi_layout_tiered(cg, tiers, orientation = "columns")
plot(cg, layout = lay_col)
```

![](https://i.imgur.com/uQtOWJm.png)<!-- -->

``` r
plot(cg, layout = lay_col, edge_style = list(route = FALSE))
```

![](https://i.imgur.com/p8ICfsJ.png)<!-- -->

<sup>Created on 2026-06-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>