### PR TITLE
fix(hd): don't let `hd()` depend on order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,9 @@
 
 ## Bug Fixes
 
+- Fix `hd()` returning results that depended on the order in which nodes were
+  declared. The Hamming distance now aligns nodes by name before comparing, so
+  logically identical graphs always give the same distance (#323).
 - Fix `dag_from_pdag()` failing with `` `from`, `edge`, `to` must be equal
   length. `` when a sink had multiple undirected neighbors (#298).
 - Fixed a bug causing a partially undirected (`--o`) edges to

--- a/src/rust/src/graph/metrics.rs
+++ b/src/rust/src/graph/metrics.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //! Class-agnostic Structural Hamming Distance over CaugiGraph.
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     edges::{EdgeClass, Mark},
@@ -138,33 +138,49 @@ pub fn shd_with_perm(truth: &CaugiGraph, guess: &CaugiGraph, perm: &[u32]) -> (f
     ((distance as f64) / (num_pairs as f64), distance)
 }
 
-/// Compute skeleton Hamming Distance (ignores edge types and directions).
+/// Compute skeleton Hamming Distance (ignores edge types and directions)
+/// between two graphs with identical node ordering.
 pub fn hd(truth: &CaugiGraph, guess: &CaugiGraph) -> (f64, usize) {
+    hd_with_perm(truth, guess, &(0..truth.n()).collect::<Vec<_>>())
+}
+
+/// Compute skeleton Hamming Distance with a node permutation mapping.
+/// `perm[i]` gives the index in `guess` that corresponds to node `i` in `truth`.
+pub fn hd_with_perm(truth: &CaugiGraph, guess: &CaugiGraph, perm: &[u32]) -> (f64, usize) {
     assert_eq!(truth.n(), guess.n(), "graph size mismatch");
+    assert_eq!(perm.len() as u32, truth.n(), "perm length mismatch");
     let n = truth.n() as usize;
     if n <= 1 {
         return (0.0, 0);
     }
 
     let mut distance = 0usize;
+    // Reuse the set across iterations to avoid repeated allocations.
+    let mut guess_nbrs: FxHashSet<u32> = FxHashSet::default();
+
     for u in 0..n {
         let row_t = truth.row_range(u as u32);
-        let row_g = guess.row_range(u as u32);
+        let row_end = row_t.end;
+        let u_in_guess = perm[u];
+
+        // Collect guess's neighbors for this row. perm[v] values are not sorted,
+        // so we cannot use the sorted cursor traversal on the guess side.
+        guess_nbrs.clear();
+        for idx in guess.row_range(u_in_guess) {
+            guess_nbrs.insert(guess.col_index[idx]);
+        }
 
         let mut cursor_t = row_t.start;
-        let mut cursor_g = row_g.start;
-
         for v in (u + 1)..n {
-            let (has_edge_t, new_cursor_t) = has_edge_to(truth, v as u32, cursor_t, row_t.end);
-            let (has_edge_g, new_cursor_g) = has_edge_to(guess, v as u32, cursor_g, row_g.end);
+            let (has_edge_t, new_cursor_t) = has_edge_to(truth, v as u32, cursor_t, row_end);
+            cursor_t = new_cursor_t;
+
+            let has_edge_g = guess_nbrs.contains(&perm[v]);
 
             // XOR: count as difference if exactly one graph has the edge
             if has_edge_t ^ has_edge_g {
                 distance += 1;
             }
-
-            cursor_t = new_cursor_t;
-            cursor_g = new_cursor_g;
         }
     }
 
@@ -490,6 +506,32 @@ mod tests {
         bg.add_edge(0, 2, dir).unwrap();
         let cg = bg.finalize().unwrap();
         assert_eq!(hd(&ct, &cg), (1.0 / 3.0, 1));
+    }
+
+    #[test]
+    fn hd_with_perm_different_node_order_same_skeleton() {
+        // Regression for issue #323: hd must not depend on node ordering.
+        // truth: A=0, B=1, C=2 with edges A-->B, B-->C
+        // guess: B=0, A=1, C=2 with edges B---A, B-->C (same skeleton)
+        let mut reg = EdgeRegistry::new();
+        reg.register_builtins().unwrap();
+        let dir = reg.code_of("-->").unwrap();
+        let und = reg.code_of("---").unwrap();
+
+        let mut bt = GraphBuilder::new_with_registry(3, true, &reg);
+        bt.add_edge(0, 1, dir).unwrap(); // A --> B
+        bt.add_edge(1, 2, dir).unwrap(); // B --> C
+        let t = bt.finalize().unwrap();
+
+        let mut bg = GraphBuilder::new_with_registry(3, true, &reg);
+        bg.add_edge(0, 1, und).unwrap(); // B --- A
+        bg.add_edge(0, 2, dir).unwrap(); // B --> C
+        let g = bg.finalize().unwrap();
+
+        // perm[i] = index in guess for truth's node i.
+        // truth A=0 -> guess A=1; truth B=1 -> guess B=0; truth C=2 -> guess C=2.
+        let perm = [1u32, 0, 2];
+        assert_eq!(hd_with_perm(&t, &g, &perm), (0.0, 0));
     }
 
     #[test]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -11,7 +11,7 @@ use graph::builder::GraphBuilder;
 
 #[cfg(feature = "gadjid")]
 use graph::metrics::aid;
-use graph::metrics::{hd, shd_with_perm};
+use graph::metrics::{hd_with_perm, shd_with_perm};
 
 use graph::view::GraphView;
 use graph::{
@@ -647,7 +647,13 @@ fn rs_shd(mut s1: ExternalPtr<GraphSession>, mut s2: ExternalPtr<GraphSession>) 
 fn rs_hd(mut s1: ExternalPtr<GraphSession>, mut s2: ExternalPtr<GraphSession>) -> Robj {
     let core1 = s1.as_mut().core().unwrap_or_else(|e| throw_r_error(e));
     let core2 = s2.as_mut().core().unwrap_or_else(|e| throw_r_error(e));
-    let (norm, count) = hd(core1.as_ref(), core2.as_ref());
+    if core1.n() != core2.n() {
+        throw_r_error("graph size mismatch");
+    }
+    let names1 = s1.as_ref().names();
+    let names2 = s2.as_ref().names();
+    let perm = build_perm_from_string_slices(names1, names2).unwrap_or_else(|e| throw_r_error(e));
+    let (norm, count) = hd_with_perm(core1.as_ref(), core2.as_ref(), &perm);
     list!(normalized = norm, count = count as i32).into_robj()
 }
 

--- a/tests/testthat/test-metrics.R
+++ b/tests/testthat/test-metrics.R
@@ -196,3 +196,14 @@ test_that("HD: same graphs but written in different ways work with hd", {
   expect_equal(hd(cg1, cg2), 0)
   reset_caugi_registry()
 })
+
+test_that("HD: does not depend on node declaration order (#323)", {
+  dag <- caugi(A %-->% B, B %-->% C)
+  pdag <- caugi(A %---% B, B %-->% C)
+  pdag2 <- caugi(B %---% A, B %-->% C)
+
+  # Same skeleton, so HD must be 0 regardless of how the edge is written.
+  expect_equal(hd(dag, pdag), 0)
+  expect_equal(hd(dag, pdag2), 0)
+  expect_equal(hd(dag, pdag), hd(dag, pdag2))
+})


### PR DESCRIPTION
`rs_hd()` (in `src/rust/src/lib.rs`) called `hd(core1, core2)` directly, comparing graphs by raw CSR index position. But two caugi objects can map the same node names to different indices. `rs_shd()` already handled this correctly, and this fix borrows directly from it.

Fixes #323