### PR TITLE
ci: remove cargo ecosystem from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "cargo"
-    directory: "/src/rust/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Every dependabot update for the cargo ecosystem requires manual intervention because the vendor archive isn't updated and cannot be automatically so via dependabot. Drop this and manually update instead.

Closes #329, closes #327, closes #328, closes #326, closes #325